### PR TITLE
Port Streamline Gateway

### DIFF
--- a/.changeset/gateway-prereqs-foundry-client.md
+++ b/.changeset/gateway-prereqs-foundry-client.md
@@ -1,0 +1,5 @@
+---
+"@party-stack/foundry-client": minor
+---
+
+Add static/confidential token providers and Party-owned `normalizeFoundryError` helpers without OSDK instanceof dependencies.

--- a/.changeset/gateway-prereqs-foundry-ontology.md
+++ b/.changeset/gateway-prereqs-foundry-ontology.md
@@ -1,0 +1,5 @@
+---
+"@party-stack/foundry-ontology": minor
+---
+
+Add ActionType RID pushdown, unredacted OMS action metadata API, Foundry link traversal via LinkedObjectsV2, media image dimensions, and normalized Foundry errors across adapter boundaries.

--- a/.changeset/gateway-prereqs-ontology.md
+++ b/.changeset/gateway-prereqs-ontology.md
@@ -1,0 +1,5 @@
+---
+"@party-stack/ontology": minor
+---
+
+Add static meta backend, runtime `pull()` coverage, optional object/action IDs and title properties, and local-first `liveOntology.links` with attachment metadata width/height.

--- a/packages/foundry-client/package.json
+++ b/packages/foundry-client/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "build": "tsc",
         "lint": "eslint",
-        "test": "vitest run --pass-with-no-tests"
+        "test": "vitest run"
     },
     "dependencies": {
         "@bobbyfidz/panic": "^0.1.0",

--- a/packages/foundry-client/src/auth/TokenProvider.ts
+++ b/packages/foundry-client/src/auth/TokenProvider.ts
@@ -1,0 +1,1 @@
+export type TokenProvider = () => Promise<string>;

--- a/packages/foundry-client/src/auth/createConfidentialTokenProvider.test.ts
+++ b/packages/foundry-client/src/auth/createConfidentialTokenProvider.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+    createConfidentialTokenProvider,
+    TokenProviderError,
+} from "./createConfidentialTokenProvider.js";
+
+function jsonResponse(body: unknown, init?: { status?: number; ok?: boolean }): Response {
+    const status = init?.status ?? 200;
+    return {
+        ok: init?.ok ?? (status >= 200 && status < 300),
+        status,
+        statusText: status === 200 ? "OK" : "Error",
+        text: () => Promise.resolve(JSON.stringify(body)),
+    } as Response;
+}
+
+describe("createConfidentialTokenProvider", () => {
+    it("acquires an initial token with client credentials and scopes", async () => {
+        const fetchImpl = vi.fn((url: string, init?: RequestInit) => {
+            expect(url).toBe("https://foundry.example/multipass/api/oauth2/token");
+            expect(init?.method).toBe("POST");
+            expect(init?.headers).toMatchObject({
+                "Content-Type": "application/x-www-form-urlencoded",
+            });
+            const rawBody = init?.body;
+            const body = new URLSearchParams(
+                typeof rawBody === "string" || rawBody instanceof URLSearchParams
+                    ? rawBody
+                    : ""
+            );
+            expect(Object.fromEntries(body.entries())).toEqual({
+                grant_type: "client_credentials",
+                client_id: "client",
+                client_secret: "secret",
+                scope: "api:read-data api:write-data",
+            });
+            return Promise.resolve(jsonResponse({ access_token: "tok-1", expires_in: 3600 }));
+        });
+
+        const provider = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            scopes: ["api:read-data", "api:write-data"],
+            fetch: fetchImpl as typeof fetch,
+        });
+
+        await expect(provider()).resolves.toBe("tok-1");
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+    });
+
+    it("caches tokens until near expiry and refreshes afterward", async () => {
+        const now = vi.spyOn(Date, "now");
+        now.mockReturnValue(1_000_000);
+        const fetchImpl = vi
+            .fn()
+            .mockResolvedValueOnce(jsonResponse({ access_token: "tok-1", expires_in: 120 }))
+            .mockResolvedValueOnce(jsonResponse({ access_token: "tok-2", expires_in: 120 }));
+
+        const provider = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: fetchImpl as typeof fetch,
+            refreshSkewMs: 30_000,
+        });
+
+        await expect(provider()).resolves.toBe("tok-1");
+        now.mockReturnValue(1_000_000 + 60_000);
+        await expect(provider()).resolves.toBe("tok-1");
+        now.mockReturnValue(1_000_000 + 100_000);
+        await expect(provider()).resolves.toBe("tok-2");
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        now.mockRestore();
+    });
+
+    it("deduplicates concurrent refresh requests", async () => {
+        let resolveFetch: ((response: Response) => void) | undefined;
+        const fetchImpl = vi.fn(
+            () =>
+                new Promise<Response>((resolve) => {
+                    resolveFetch = resolve;
+                })
+        );
+
+        const provider = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: fetchImpl as typeof fetch,
+        });
+
+        const first = provider();
+        const second = provider();
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        resolveFetch?.(jsonResponse({ access_token: "shared", expires_in: 3600 }));
+        await expect(Promise.all([first, second])).resolves.toEqual(["shared", "shared"]);
+    });
+
+    it("throws useful errors for unsuccessful and malformed responses", async () => {
+        const unsuccessful = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: (() =>
+                Promise.resolve(
+                    jsonResponse(
+                        { error: "invalid_client", error_description: "bad secret" },
+                        { status: 401 }
+                    )
+                )) as typeof fetch,
+        });
+        await expect(unsuccessful()).rejects.toBeInstanceOf(TokenProviderError);
+        await expect(unsuccessful()).rejects.toThrow(/401.*bad secret/);
+
+        const malformed = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: (() =>
+                Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    statusText: "OK",
+                    text: () => Promise.resolve("not-json"),
+                } as Response)) as typeof fetch,
+        });
+        await expect(malformed()).rejects.toThrow(/not valid JSON/);
+
+        const missingToken = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: (() => Promise.resolve(jsonResponse({ expires_in: 60 }))) as typeof fetch,
+        });
+        await expect(missingToken()).rejects.toThrow(/access_token/);
+    });
+
+    it("uses a custom fetch implementation", async () => {
+        const fetchImpl = vi.fn(() =>
+            Promise.resolve(jsonResponse({ access_token: "custom", expires_in: 60 }))
+        );
+        const provider = createConfidentialTokenProvider({
+            foundryUrl: "https://foundry.example/",
+            clientId: "client",
+            clientSecret: "secret",
+            fetch: fetchImpl as typeof fetch,
+        });
+        await expect(provider()).resolves.toBe("custom");
+        expect(fetchImpl).toHaveBeenCalledWith(
+            "https://foundry.example/multipass/api/oauth2/token",
+            expect.any(Object)
+        );
+    });
+});

--- a/packages/foundry-client/src/auth/createConfidentialTokenProvider.ts
+++ b/packages/foundry-client/src/auth/createConfidentialTokenProvider.ts
@@ -1,0 +1,153 @@
+import type { TokenProvider } from "./TokenProvider.js";
+
+export interface CreateConfidentialTokenProviderOptions {
+    foundryUrl: string;
+    clientId: string;
+    clientSecret: string;
+    scopes?: string[];
+    fetch?: typeof globalThis.fetch;
+    /** Refresh this many milliseconds before expiry. Defaults to 60_000. */
+    refreshSkewMs?: number;
+}
+
+export class TokenProviderError extends Error {
+    readonly status?: number;
+    readonly body?: string;
+
+    constructor(message: string, opts?: { status?: number; body?: string; cause?: unknown }) {
+        super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+        this.name = "TokenProviderError";
+        this.status = opts?.status;
+        this.body = opts?.body;
+    }
+}
+
+interface TokenResponse {
+    access_token?: unknown;
+    expires_in?: unknown;
+    token_type?: unknown;
+    error?: unknown;
+    error_description?: unknown;
+}
+
+interface CachedToken {
+    accessToken: string;
+    expiresAtMs: number;
+}
+
+function joinUrl(baseUrl: string, pathname: string): string {
+    const normalizedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl;
+    const normalizedPath = pathname.startsWith("/") ? pathname : `/${pathname}`;
+    return `${normalizedBase}${normalizedPath}`;
+}
+
+function parseExpiresInSeconds(value: unknown): number {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+        return value;
+    }
+    if (typeof value === "string" && value.trim().length > 0) {
+        const parsed = Number(value);
+        if (Number.isFinite(parsed) && parsed > 0) {
+            return parsed;
+        }
+    }
+    // Foundry tokens are typically short-lived; fall back to 5 minutes if omitted.
+    return 300;
+}
+
+/**
+ * OAuth2 client-credentials token provider suitable for Cloudflare Workers and Node.
+ * Caches tokens, refreshes before expiry, and deduplicates concurrent refresh requests.
+ */
+export function createConfidentialTokenProvider(
+    opts: CreateConfidentialTokenProviderOptions
+): TokenProvider {
+    const fetchImpl = opts.fetch ?? globalThis.fetch;
+    if (typeof fetchImpl !== "function") {
+        throw new Error("createConfidentialTokenProvider requires a fetch implementation.");
+    }
+
+    const refreshSkewMs = opts.refreshSkewMs ?? 60_000;
+    const tokenUrl = joinUrl(opts.foundryUrl, "/multipass/api/oauth2/token");
+    let cached: CachedToken | undefined;
+    let inflight: Promise<string> | undefined;
+
+    const acquire = async (): Promise<string> => {
+        const body = new URLSearchParams({
+            grant_type: "client_credentials",
+            client_id: opts.clientId,
+            client_secret: opts.clientSecret,
+        });
+        if (opts.scopes && opts.scopes.length > 0) {
+            body.set("scope", opts.scopes.join(" "));
+        }
+
+        let response: Response;
+        try {
+            response = await fetchImpl(tokenUrl, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+                body,
+            });
+        } catch (error) {
+            throw new TokenProviderError("Failed to request Foundry OAuth token.", { cause: error });
+        }
+
+        const rawBody = await response.text();
+        let parsed: TokenResponse;
+        try {
+            parsed = rawBody.length > 0 ? (JSON.parse(rawBody) as TokenResponse) : {};
+        } catch (error) {
+            throw new TokenProviderError("Foundry OAuth token response was not valid JSON.", {
+                status: response.status,
+                body: rawBody,
+                cause: error,
+            });
+        }
+
+        if (!response.ok) {
+            const details =
+                typeof parsed.error_description === "string"
+                    ? parsed.error_description
+                    : typeof parsed.error === "string"
+                      ? parsed.error
+                      : response.statusText;
+            throw new TokenProviderError(
+                `Foundry OAuth token request failed with status ${response.status}: ${details}`,
+                {
+                    status: response.status,
+                    body: rawBody,
+                }
+            );
+        }
+
+        if (typeof parsed.access_token !== "string" || parsed.access_token.length === 0) {
+            throw new TokenProviderError("Foundry OAuth token response did not include access_token.", {
+                status: response.status,
+                body: rawBody,
+            });
+        }
+
+        const expiresInSeconds = parseExpiresInSeconds(parsed.expires_in);
+        cached = {
+            accessToken: parsed.access_token,
+            expiresAtMs: Date.now() + expiresInSeconds * 1000,
+        };
+        return cached.accessToken;
+    };
+
+    return async () => {
+        if (cached && cached.expiresAtMs - refreshSkewMs > Date.now()) {
+            return cached.accessToken;
+        }
+
+        if (!inflight) {
+            inflight = acquire().finally(() => {
+                inflight = undefined;
+            });
+        }
+        return inflight;
+    };
+}

--- a/packages/foundry-client/src/auth/createStaticTokenProvider.test.ts
+++ b/packages/foundry-client/src/auth/createStaticTokenProvider.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createStaticTokenProvider } from "./createStaticTokenProvider.js";
+
+describe("createStaticTokenProvider", () => {
+    it("returns a static token", async () => {
+        const provider = createStaticTokenProvider({ token: "token-1" });
+        await expect(provider()).resolves.toBe("token-1");
+        await expect(provider()).resolves.toBe("token-1");
+    });
+
+    it("supports sync and async token resolvers", async () => {
+        await expect(createStaticTokenProvider({ token: () => "sync" })()).resolves.toBe("sync");
+        await expect(
+            createStaticTokenProvider({
+                token: () => Promise.resolve("async"),
+            })()
+        ).resolves.toBe("async");
+    });
+
+    it("rejects empty tokens", async () => {
+        await expect(createStaticTokenProvider({ token: "" })()).rejects.toThrow(/empty token/);
+        await expect(createStaticTokenProvider({ token: () => "" })()).rejects.toThrow(/empty token/);
+    });
+});

--- a/packages/foundry-client/src/auth/createStaticTokenProvider.ts
+++ b/packages/foundry-client/src/auth/createStaticTokenProvider.ts
@@ -1,0 +1,19 @@
+import type { TokenProvider } from "./TokenProvider.js";
+
+export interface CreateStaticTokenProviderOptions {
+    token: string | (() => string | Promise<string>);
+}
+
+/**
+ * Returns a {@link TokenProvider} that always resolves to the given bearer token.
+ * Accepts either a static string or a sync/async resolver.
+ */
+export function createStaticTokenProvider(opts: CreateStaticTokenProviderOptions): TokenProvider {
+    return async () => {
+        const token = typeof opts.token === "function" ? await opts.token() : opts.token;
+        if (typeof token !== "string" || token.length === 0) {
+            throw new Error("Static token provider resolved to an empty token.");
+        }
+        return token;
+    };
+}

--- a/packages/foundry-client/src/auth/index.ts
+++ b/packages/foundry-client/src/auth/index.ts
@@ -1,0 +1,7 @@
+export * from "./TokenProvider.js";
+export * from "./createStaticTokenProvider.js";
+export {
+    createConfidentialTokenProvider,
+    TokenProviderError,
+    type CreateConfidentialTokenProviderOptions,
+} from "./createConfidentialTokenProvider.js";

--- a/packages/foundry-client/src/errors/index.ts
+++ b/packages/foundry-client/src/errors/index.ts
@@ -1,0 +1,1 @@
+export * from "./normalizeFoundryError.js";

--- a/packages/foundry-client/src/errors/normalizeFoundryError.test.ts
+++ b/packages/foundry-client/src/errors/normalizeFoundryError.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+import {
+    FoundryActionValidationError,
+    FoundryError,
+    isFoundryAuthError,
+    isFoundryNotFoundError,
+    normalizeFoundryError,
+} from "./normalizeFoundryError.js";
+
+describe("normalizeFoundryError", () => {
+    it("normalizes Palantir-like API errors structurally", () => {
+        const cause = {
+            message: "Object not found",
+            statusCode: 404,
+            errorCode: "NOT_FOUND",
+            errorName: "ObjectNotFound",
+            errorInstanceId: "abc",
+            parameters: { objectType: "Employee", primaryKey: "1" },
+        };
+
+        const normalized = normalizeFoundryError(cause);
+        expect(normalized).toBeInstanceOf(FoundryError);
+        expect(normalized).toMatchObject({
+            message: "Object not found",
+            statusCode: 404,
+            errorCode: "NOT_FOUND",
+            errorName: "ObjectNotFound",
+            errorInstanceId: "abc",
+            parameters: { objectType: "Employee", primaryKey: "1" },
+        });
+        expect(normalized.cause).toBe(cause);
+        expect(isFoundryNotFoundError(cause)).toBe(true);
+    });
+
+    it("normalizes action validation errors", () => {
+        const cause = {
+            name: "ActionValidationError",
+            message: "Invalid parameters",
+            errorCode: "INVALID_ARGUMENT",
+            validation: { result: "INVALID", parameters: { title: { result: "INVALID" } } },
+            parameters: { actionType: "createPost" },
+        };
+
+        const normalized = normalizeFoundryError(cause);
+        expect(normalized).toBeInstanceOf(FoundryActionValidationError);
+        expect(normalized).toMatchObject({
+            message: "Invalid parameters",
+            errorCode: "INVALID_ARGUMENT",
+            errorName: "ActionValidationError",
+        });
+        expect((normalized as FoundryActionValidationError).validation).toEqual(cause.validation);
+    });
+
+    it("finds structured validation details through non-retryable wrappers", () => {
+        const validation = {
+            result: "INVALID",
+            parameters: { title: { result: "INVALID", message: "Required" } },
+        };
+        const cause = new FoundryActionValidationError("Invalid Action arguments.", {
+            statusCode: 400,
+            validation,
+            parameters: { actionType: "createPost" },
+        });
+        const wrapper = new Error("Action execution is non-retryable.", { cause });
+        wrapper.name = "NonRetryableError";
+
+        const normalized = normalizeFoundryError(wrapper);
+        expect(normalized).toBeInstanceOf(FoundryActionValidationError);
+        expect(normalized).toMatchObject({
+            message: "Action execution is non-retryable.",
+            statusCode: 400,
+            errorCode: "INVALID_ARGUMENT",
+            errorName: "ActionValidationError",
+            parameters: { actionType: "createPost" },
+            validation,
+        });
+        expect(normalized.cause).toBe(wrapper);
+    });
+
+    it("handles unknown and malformed payloads while preserving causes", () => {
+        expect(normalizeFoundryError("boom")).toMatchObject({
+            message: "boom",
+        });
+        expect(normalizeFoundryError(null).message).toBe("Unknown Foundry error.");
+        expect(normalizeFoundryError({ statusCode: "nope", parameters: "bad" }).message).toBe(
+            "Unknown Foundry error."
+        );
+
+        const original = new Error("network down");
+        const normalized = normalizeFoundryError(original);
+        expect(normalized.message).toBe("network down");
+        expect(normalized.cause).toBe(original);
+    });
+
+    it("returns existing Party Stack errors unchanged", () => {
+        const existing = new FoundryError("already normalized", { errorCode: "CONFLICT", statusCode: 409 });
+        expect(normalizeFoundryError(existing)).toBe(existing);
+    });
+
+    it("detects auth errors", () => {
+        expect(isFoundryAuthError({ statusCode: 401, errorCode: "UNAUTHORIZED" })).toBe(true);
+        expect(isFoundryAuthError({ statusCode: 403 })).toBe(true);
+        expect(isFoundryAuthError({ statusCode: 500 })).toBe(false);
+    });
+});

--- a/packages/foundry-client/src/errors/normalizeFoundryError.ts
+++ b/packages/foundry-client/src/errors/normalizeFoundryError.ts
@@ -1,0 +1,187 @@
+export class FoundryError extends Error {
+    readonly statusCode?: number;
+    readonly errorCode?: string;
+    readonly errorName?: string;
+    readonly errorInstanceId?: string;
+    readonly parameters?: Record<string, unknown>;
+
+    constructor(
+        message: string,
+        opts?: {
+            statusCode?: number;
+            errorCode?: string;
+            errorName?: string;
+            errorInstanceId?: string;
+            parameters?: Record<string, unknown>;
+            cause?: unknown;
+        }
+    ) {
+        super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+        this.name = "FoundryError";
+        this.statusCode = opts?.statusCode;
+        this.errorCode = opts?.errorCode;
+        this.errorName = opts?.errorName;
+        this.errorInstanceId = opts?.errorInstanceId;
+        this.parameters = opts?.parameters;
+    }
+}
+
+export class FoundryActionValidationError extends FoundryError {
+    readonly validation?: unknown;
+
+    constructor(
+        message: string,
+        opts?: {
+            statusCode?: number;
+            errorCode?: string;
+            errorName?: string;
+            errorInstanceId?: string;
+            parameters?: Record<string, unknown>;
+            validation?: unknown;
+            cause?: unknown;
+        }
+    ) {
+        super(message, {
+            statusCode: opts?.statusCode,
+            errorCode: opts?.errorCode ?? "INVALID_ARGUMENT",
+            errorName: opts?.errorName ?? "ActionValidationError",
+            errorInstanceId: opts?.errorInstanceId,
+            parameters: opts?.parameters,
+            cause: opts?.cause,
+        });
+        this.name = "FoundryActionValidationError";
+        this.validation = opts?.validation;
+    }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+    return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function asParameters(value: unknown): Record<string, unknown> | undefined {
+    return isRecord(value) ? value : undefined;
+}
+
+function readErrorFields(
+    error: unknown,
+    seen: Set<object> = new Set()
+): {
+    message?: string;
+    statusCode?: number;
+    errorCode?: string;
+    errorName?: string;
+    errorInstanceId?: string;
+    parameters?: Record<string, unknown>;
+    validation?: unknown;
+} {
+    if (!isRecord(error)) {
+        return {};
+    }
+    if (seen.has(error)) {
+        return {};
+    }
+    seen.add(error);
+
+    const causeFields = readErrorFields(error.cause, seen);
+
+    return {
+        message: asString(error.message) ?? causeFields.message,
+        statusCode:
+            asNumber(error.statusCode) ??
+            asNumber(error.status) ??
+            causeFields.statusCode,
+        errorCode:
+            asString(error.errorCode) ??
+            asString(error.code) ??
+            causeFields.errorCode,
+        errorName:
+            asString(error.errorName) ??
+            causeFields.errorName ??
+            (asString(error.name) === "Error" ? undefined : asString(error.name)),
+        errorInstanceId:
+            asString(error.errorInstanceId) ??
+            asString(error.instanceId) ??
+            causeFields.errorInstanceId,
+        parameters: asParameters(error.parameters) ?? causeFields.parameters,
+        validation:
+            error.validation ??
+            error.actionValidation ??
+            causeFields.validation,
+    };
+}
+
+function isActionValidationLike(error: unknown, fields: ReturnType<typeof readErrorFields>): boolean {
+    if (error instanceof FoundryActionValidationError) {
+        return true;
+    }
+    if (!isRecord(error)) {
+        return false;
+    }
+    const name = fields.errorName ?? asString(error.name);
+    if (name === "ActionValidationError" || name === "FoundryActionValidationError") {
+        return true;
+    }
+    if (fields.errorCode === "INVALID_ARGUMENT" && fields.validation !== undefined) {
+        return true;
+    }
+    return fields.validation !== undefined && asString(error.name) === "ActionValidationError";
+}
+
+/**
+ * Structurally normalizes Foundry/OSDK errors into Party Stack-owned error types.
+ * Does not rely on `instanceof` against OSDK classes (which can fail across package copies).
+ */
+export function normalizeFoundryError(error: unknown): FoundryError {
+    if (error instanceof FoundryError) {
+        return error;
+    }
+
+    const fields = readErrorFields(error);
+    const message =
+        fields.message ??
+        (typeof error === "string" && error.length > 0 ? error : "Unknown Foundry error.");
+
+    if (isActionValidationLike(error, fields)) {
+        return new FoundryActionValidationError(message, {
+            statusCode: fields.statusCode,
+            errorCode: fields.errorCode,
+            errorName: fields.errorName,
+            errorInstanceId: fields.errorInstanceId,
+            parameters: fields.parameters,
+            validation: fields.validation,
+            cause: error,
+        });
+    }
+
+    return new FoundryError(message, {
+        statusCode: fields.statusCode,
+        errorCode: fields.errorCode,
+        errorName: fields.errorName,
+        errorInstanceId: fields.errorInstanceId,
+        parameters: fields.parameters,
+        cause: error,
+    });
+}
+
+export function isFoundryNotFoundError(error: unknown): boolean {
+    const normalized = normalizeFoundryError(error);
+    return normalized.statusCode === 404 || normalized.errorCode === "NOT_FOUND";
+}
+
+export function isFoundryAuthError(error: unknown): boolean {
+    const normalized = normalizeFoundryError(error);
+    return (
+        normalized.statusCode === 401 ||
+        normalized.statusCode === 403 ||
+        normalized.errorCode === "UNAUTHORIZED" ||
+        normalized.errorCode === "PERMISSION_DENIED"
+    );
+}

--- a/packages/foundry-client/src/index.ts
+++ b/packages/foundry-client/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./client.js";
+export * from "./auth/index.js";
+export * from "./errors/index.js";

--- a/packages/foundry-ontology/src/adapter/createFoundryLinksAdapter.test.ts
+++ b/packages/foundry-ontology/src/adapter/createFoundryLinksAdapter.test.ts
@@ -1,0 +1,161 @@
+import { o, OntologyLinkError, type OntologyIR } from "@party-stack/ontology";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OntologyClient } from "@party-stack/foundry-client";
+import { createFoundryLinksAdapter } from "./createFoundryLinksAdapter.js";
+import { createFoundryCodec } from "./foundryCodec.js";
+
+const mocks = vi.hoisted(() => ({
+    listLinkedObjects: vi.fn(),
+    getLinkedObject: vi.fn(),
+}));
+
+vi.mock("@osdk/foundry.ontologies", () => ({
+    LinkedObjectsV2: {
+        listLinkedObjects: mocks.listLinkedObjects,
+        getLinkedObject: mocks.getLinkedObject,
+    },
+}));
+
+const ir: OntologyIR = {
+    types: [],
+    objectTypes: [
+        {
+            name: "Employee",
+            displayName: "Employee",
+            pluralDisplayName: "Employees",
+            primaryKey: "id",
+            properties: [
+                { name: "id", displayName: "Id", type: o.string({}) },
+                { name: "name", displayName: "Name", type: o.string({}) },
+            ],
+        },
+        {
+            name: "Project",
+            displayName: "Project",
+            pluralDisplayName: "Projects",
+            primaryKey: "id",
+            properties: [
+                { name: "id", displayName: "Id", type: o.string({}) },
+                { name: "title", displayName: "Title", type: o.string({}) },
+            ],
+        },
+    ],
+    linkTypes: [
+        {
+            id: "ri.link.employee-projects",
+            source: {
+                objectType: "Employee",
+                name: "members",
+                displayName: "Members",
+                cardinality: "many",
+            },
+            target: {
+                objectType: "Project",
+                name: "projects",
+                displayName: "Projects",
+                cardinality: "many",
+            },
+            cardinality: "many",
+        },
+    ],
+    actionTypes: [],
+    queryFunctionTypes: [],
+};
+
+function client(): OntologyClient {
+    return {
+        baseUrl: "https://foundry.example.com",
+        ontologyRid: "ri.ontology.main.ontology.example",
+        tokenProvider: () => Promise.resolve("token"),
+        fetch: globalThis.fetch,
+    };
+}
+
+beforeEach(() => {
+    mocks.listLinkedObjects.mockReset();
+    mocks.getLinkedObject.mockReset();
+});
+
+describe("createFoundryLinksAdapter", () => {
+    it("lists linked objects through LinkedObjectsV2 and decodes them", async () => {
+        mocks.listLinkedObjects.mockResolvedValue({
+            data: [{ id: "p1", title: "Launch" }],
+            nextPageToken: "next",
+        });
+
+        const adapter = createFoundryLinksAdapter({
+            client: client(),
+            ir,
+            codec: createFoundryCodec(ir),
+        });
+
+        const page = await adapter.list({
+            objectType: "Employee",
+            primaryKey: "e1",
+            link: { sideName: "projects" },
+            pageSize: 50,
+            select: ["title"],
+        });
+
+        expect(mocks.listLinkedObjects).toHaveBeenCalledWith(
+            expect.anything(),
+            "ri.ontology.main.ontology.example",
+            "Employee",
+            "e1",
+            "projects",
+            expect.objectContaining({
+                pageSize: 50,
+                select: ["id", "title"],
+            })
+        );
+        expect(page).toEqual({
+            objects: [
+                {
+                    objectType: "Project",
+                    primaryKey: "p1",
+                    properties: { id: "p1", title: "Launch" },
+                },
+            ],
+            nextPageToken: "next",
+        });
+    });
+
+    it("gets a linked object by primary key", async () => {
+        mocks.getLinkedObject.mockResolvedValue({ id: "p1", title: "Launch" });
+
+        const adapter = createFoundryLinksAdapter({
+            client: client(),
+            ir,
+            codec: createFoundryCodec(ir),
+        });
+
+        await expect(
+            adapter.get({
+                objectType: "Employee",
+                primaryKey: "e1",
+                link: { sideName: "projects" },
+                linkedPrimaryKey: "p1",
+            })
+        ).resolves.toEqual({
+            objectType: "Project",
+            primaryKey: "p1",
+            properties: { id: "p1", title: "Launch" },
+        });
+    });
+
+    it("rejects to-many get without linkedPrimaryKey", async () => {
+        const adapter = createFoundryLinksAdapter({
+            client: client(),
+            ir,
+            codec: createFoundryCodec(ir),
+        });
+
+        await expect(
+            adapter.get({
+                objectType: "Employee",
+                primaryKey: "e1",
+                link: { sideName: "projects" },
+            })
+        ).rejects.toBeInstanceOf(OntologyLinkError);
+    });
+});

--- a/packages/foundry-ontology/src/adapter/createFoundryLinksAdapter.ts
+++ b/packages/foundry-ontology/src/adapter/createFoundryLinksAdapter.ts
@@ -1,0 +1,183 @@
+import { LinkedObjectsV2, type OntologyObjectV2 } from "@osdk/foundry.ontologies";
+import {
+    normalizeFoundryError,
+    isFoundryNotFoundError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
+import {
+    OntologyLinkError,
+    resolveOntologyLink,
+    type OntologyGetLinkOpts,
+    type OntologyIR,
+    type OntologyLinkedObject,
+    type OntologyLinkPage,
+    type OntologyLinksAdapter,
+    type OntologyListLinksOpts,
+} from "@party-stack/ontology";
+import type { FoundryCodec } from "./foundryCodec.js";
+
+function escapePrimaryKey(primaryKey: string | number): string {
+    return encodeURIComponent(String(primaryKey));
+}
+
+function requireObjectType(ir: OntologyIR, objectType: string) {
+    const def = ir.objectTypes.find((candidate) => candidate.name === objectType);
+    if (!def) {
+        throw new OntologyLinkError(`Unknown object type "${objectType}".`);
+    }
+    return def;
+}
+
+function selectedProperties(
+    ir: OntologyIR,
+    objectType: string,
+    primaryKey: string,
+    select?: string[]
+): string[] {
+    const selected =
+        select ??
+        ir.objectTypes
+            .find((candidate) => candidate.name === objectType)
+            ?.properties.map((property) => property.name) ??
+        [];
+    return Array.from(new Set([primaryKey, ...selected]));
+}
+
+function toLinkedObject(
+    codec: FoundryCodec,
+    objectType: string,
+    primaryKeyProperty: string,
+    raw: OntologyObjectV2
+): OntologyLinkedObject {
+    const properties = codec.decodeObject(objectType, raw);
+    const primaryKey = properties[primaryKeyProperty];
+    if (typeof primaryKey !== "string" && typeof primaryKey !== "number") {
+        throw new OntologyLinkError(
+            `Linked ${objectType} object is missing primary key property "${primaryKeyProperty}".`
+        );
+    }
+    return {
+        objectType,
+        primaryKey,
+        properties,
+    };
+}
+
+export function createFoundryLinksAdapter(opts: {
+    client: OntologyClient;
+    ir: OntologyIR;
+    codec: FoundryCodec;
+}): OntologyLinksAdapter {
+    return {
+        list: async (listOpts: OntologyListLinksOpts): Promise<OntologyLinkPage> => {
+            const resolved = resolveOntologyLink(opts.ir, listOpts.objectType, listOpts.link);
+            const target = requireObjectType(opts.ir, resolved.targetObjectType);
+            const select = selectedProperties(
+                opts.ir,
+                resolved.targetObjectType,
+                target.primaryKey,
+                listOpts.select
+            );
+
+            try {
+                const response = await LinkedObjectsV2.listLinkedObjects(
+                    opts.client,
+                    opts.client.ontologyRid,
+                    listOpts.objectType,
+                    escapePrimaryKey(listOpts.primaryKey),
+                    resolved.sideName,
+                    {
+                        pageSize: listOpts.pageSize,
+                        pageToken: listOpts.pageToken,
+                        select,
+                    }
+                );
+
+                return {
+                    objects: response.data.map((object) =>
+                        toLinkedObject(opts.codec, resolved.targetObjectType, target.primaryKey, object)
+                    ),
+                    nextPageToken: response.nextPageToken,
+                };
+            } catch (error) {
+                const normalized = normalizeFoundryError(error);
+                if (isFoundryNotFoundError(normalized)) {
+                    throw new OntologyLinkError(
+                        `Link "${listOpts.objectType}.${resolved.sideName}" was not found for primary key "${listOpts.primaryKey}".`,
+                        { cause: normalized }
+                    );
+                }
+                throw normalized;
+            }
+        },
+        get: async (getOpts: OntologyGetLinkOpts): Promise<OntologyLinkedObject | undefined> => {
+            const resolved = resolveOntologyLink(opts.ir, getOpts.objectType, getOpts.link);
+            const target = requireObjectType(opts.ir, resolved.targetObjectType);
+            const select = selectedProperties(
+                opts.ir,
+                resolved.targetObjectType,
+                target.primaryKey,
+                getOpts.select
+            );
+
+            if (getOpts.linkedPrimaryKey !== undefined) {
+                try {
+                    const object = await LinkedObjectsV2.getLinkedObject(
+                        opts.client,
+                        opts.client.ontologyRid,
+                        getOpts.objectType,
+                        escapePrimaryKey(getOpts.primaryKey),
+                        resolved.sideName,
+                        escapePrimaryKey(getOpts.linkedPrimaryKey),
+                        { select }
+                    );
+                    return toLinkedObject(opts.codec, resolved.targetObjectType, target.primaryKey, object);
+                } catch (error) {
+                    const normalized = normalizeFoundryError(error);
+                    if (isFoundryNotFoundError(normalized)) {
+                        return undefined;
+                    }
+                    throw normalized;
+                }
+            }
+
+            if (resolved.cardinality === "many") {
+                throw new OntologyLinkError(
+                    `Link "${getOpts.objectType}.${resolved.sideName}" is to-many; use links.list().`
+                );
+            }
+
+            let response: { data: OntologyObjectV2[] };
+            try {
+                response = await LinkedObjectsV2.listLinkedObjects(
+                    opts.client,
+                    opts.client.ontologyRid,
+                    getOpts.objectType,
+                    escapePrimaryKey(getOpts.primaryKey),
+                    resolved.sideName,
+                    {
+                        pageSize: 2,
+                        select,
+                    }
+                );
+            } catch (error) {
+                const normalized = normalizeFoundryError(error);
+                if (isFoundryNotFoundError(normalized)) {
+                    return undefined;
+                }
+                throw normalized;
+            }
+
+            if (response.data.length > 1) {
+                throw new OntologyLinkError(
+                    `Expected at most one linked object for "${getOpts.objectType}.${resolved.sideName}" but Foundry returned ${response.data.length}.`
+                );
+            }
+
+            const raw = response.data[0];
+            return raw
+                ? toLinkedObject(opts.codec, resolved.targetObjectType, target.primaryKey, raw)
+                : undefined;
+        },
+    };
+}

--- a/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.test.ts
+++ b/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.test.ts
@@ -1,14 +1,17 @@
-import { o } from "@party-stack/ontology";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OntologyClient } from "@party-stack/foundry-client";
 import {
-    createFoundryOntologyBackendAdapter,
+    FoundryActionValidationError,
     isFoundryNotFoundError,
-} from "./createFoundryOntologyBackendAdapter.js";
+    normalizeFoundryError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
+import { NonRetryableError, o } from "@party-stack/ontology";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createFoundryOntologyBackendAdapter } from "./createFoundryOntologyBackendAdapter.js";
 import { encodeFoundryMediaId } from "./foundryMediaId.js";
 
 const mediaMocks = vi.hoisted(() => ({
     uploadMedia: vi.fn(),
+    metadata: vi.fn(),
 }));
 const ontologyMocks = vi.hoisted(() => ({
     applyWithOverrides: vi.fn(),
@@ -37,6 +40,10 @@ vi.mock("@osdk/foundry.ontologies", async (importOriginal) => {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    mediaMocks.metadata.mockResolvedValue({
+        type: "imagery",
+        dimensions: { width: 640, height: 480 },
+    });
 });
 
 describe("isFoundryNotFoundError", () => {
@@ -176,6 +183,40 @@ describe("Foundry media attachments", () => {
         });
     });
 
+    it("preserves invalid action validation details in a non-retryable error", async () => {
+        const validation = {
+            result: "INVALID",
+            parameters: {
+                media: {
+                    result: "INVALID",
+                    message: "Media is required.",
+                },
+            },
+        };
+        ontologyMocks.applyWithOverrides.mockResolvedValue({
+            validation,
+            edits: { type: "edits", edits: [] },
+        });
+
+        const error = await adapter
+            .applyAction("createMedia", {}, { objects: {} })
+            .then(
+                () => undefined,
+                (cause: unknown) => cause
+            );
+
+        expect(error).toBeInstanceOf(NonRetryableError);
+        const normalized = normalizeFoundryError(error);
+        expect(normalized).toBeInstanceOf(FoundryActionValidationError);
+        expect(normalized).toMatchObject({
+            statusCode: 400,
+            errorCode: "INVALID_ARGUMENT",
+            errorName: "ActionValidationError",
+            parameters: { actionType: "createMedia" },
+            validation,
+        });
+    });
+
     it("reads confirmed media through its object property source", async () => {
         const id = encodeFoundryMediaId(mediaId);
         const attachment = {
@@ -200,8 +241,18 @@ describe("Foundry media attachments", () => {
         await expect(attachments.getAttachmentMetadata(attachment)).resolves.toEqual({
             ...attachment,
             size: 5,
+            type: "image/png",
             name: undefined,
+            width: 640,
+            height: 480,
+            provider: "media",
         });
+        expect(mediaMocks.metadata).toHaveBeenCalledWith(
+            expect.anything(),
+            mediaId.mediaSetRid,
+            mediaId.mediaItemRid,
+            { preview: true }
+        );
         expect(ontologyMocks.getMediaContent).toHaveBeenCalledWith(
             expect.anything(),
             "ri.ontology.main.1",

--- a/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.ts
+++ b/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.ts
@@ -8,6 +8,12 @@ import {
     Queries,
 } from "@osdk/foundry.ontologies";
 import {
+    FoundryActionValidationError,
+    isFoundryNotFoundError,
+    normalizeFoundryError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
+import {
     NonRetryableError,
     type OntologyAttachmentIdMapping,
     type OntologyBackendAdapter,
@@ -17,23 +23,12 @@ import {
 } from "@party-stack/ontology";
 import { Collection } from "@tanstack/db";
 import { Temporal } from "temporal-polyfill";
-import type { OntologyClient } from "@party-stack/foundry-client";
 import { getFoundryActionOverrideParameterMapping } from "../meta/convertMetaActionType.js";
 import { toFoundryActionTypeName } from "../utils/actionTypeName.js";
+import { createFoundryLinksAdapter } from "./createFoundryLinksAdapter.js";
 import { createFoundryCodec } from "./foundryCodec.js";
 import { decodeFoundryMediaId, mediaReferenceToFoundryMediaId } from "./foundryMediaId.js";
 import { objectCollectionOptions, type ObjectCollectionUtils } from "./objectCollectionOptions.js";
-
-export function isFoundryNotFoundError(error: unknown): boolean {
-    if (typeof error !== "object" || error === null) {
-        return false;
-    }
-    const foundryError = error as {
-        statusCode?: unknown;
-        errorCode?: unknown;
-    };
-    return foundryError.statusCode === 404 || foundryError.errorCode === "NOT_FOUND";
-}
 
 type FoundryObject = Record<string, unknown>;
 
@@ -130,65 +125,95 @@ export function createFoundryOntologyBackendAdapter(opts: {
             try {
                 await Attachments.get(opts.client, attachment.id as AttachmentRid);
                 return;
-            } catch {
-                // The stable attachment RID has not been materialized yet.
+            } catch (error) {
+                const normalized = normalizeFoundryError(error);
+                if (!isFoundryNotFoundError(normalized)) {
+                    throw normalized;
+                }
             }
-            await Attachments.uploadWithRid(opts.client, attachment.id as AttachmentRid, blob, {
-                filename: getAttachmentName(attachment as unknown) ?? "",
-                preview: true,
-            });
+            try {
+                await Attachments.uploadWithRid(opts.client, attachment.id as AttachmentRid, blob, {
+                    filename: getAttachmentName(attachment as unknown) ?? "",
+                    preview: true,
+                });
+            } catch (error) {
+                throw normalizeFoundryError(error);
+            }
         },
         getAttachmentContent: async (attachment) => {
-            const media = decodeFoundryMediaId(attachment.id);
-            if (media) {
-                const source = attachment.source;
-                invariant(
-                    source,
-                    `Foundry media attachment "${attachment.id}" is missing its object property source.`
-                );
-                const response = await MediaReferenceProperties.getMediaContent(
-                    opts.client,
-                    opts.client.ontologyRid,
-                    source.objectType,
-                    String(source.primaryKey),
-                    source.property,
-                    { preview: true }
-                );
-                return response.blob();
+            try {
+                const media = decodeFoundryMediaId(attachment.id);
+                if (media) {
+                    const source = attachment.source;
+                    invariant(
+                        source,
+                        `Foundry media attachment "${attachment.id}" is missing its object property source.`
+                    );
+                    const response = await MediaReferenceProperties.getMediaContent(
+                        opts.client,
+                        opts.client.ontologyRid,
+                        source.objectType,
+                        String(source.primaryKey),
+                        source.property,
+                        { preview: true }
+                    );
+                    return response.blob();
+                }
+                const contents = await Attachments.read(opts.client, attachment.id as AttachmentRid);
+                return contents.blob();
+            } catch (error) {
+                throw normalizeFoundryError(error);
             }
-            const contents = await Attachments.read(opts.client, attachment.id as AttachmentRid);
-            return contents.blob();
         },
         getAttachmentMetadata: async (attachment) => {
-            const media = decodeFoundryMediaId(attachment.id);
-            if (media) {
-                const source = attachment.source;
-                invariant(
-                    source,
-                    `Foundry media attachment "${attachment.id}" is missing its object property source.`
-                );
-                const info = await MediaReferenceProperties.getMediaMetadata(
-                    opts.client,
-                    opts.client.ontologyRid,
-                    source.objectType,
-                    String(source.primaryKey),
-                    source.property,
-                    { preview: true }
-                );
+            try {
+                const media = decodeFoundryMediaId(attachment.id);
+                if (media) {
+                    const source = attachment.source;
+                    invariant(
+                        source,
+                        `Foundry media attachment "${attachment.id}" is missing its object property source.`
+                    );
+                    const [info, dimensions] = await Promise.all([
+                        MediaReferenceProperties.getMediaMetadata(
+                            opts.client,
+                            opts.client.ontologyRid,
+                            source.objectType,
+                            String(source.primaryKey),
+                            source.property,
+                            { preview: true }
+                        ),
+                        MediaSets.metadata(opts.client, media.mediaSetRid, media.mediaItemRid, {
+                            preview: true,
+                        })
+                            .then((metadata) =>
+                                metadata.type === "imagery" && metadata.dimensions
+                                    ? metadata.dimensions
+                                    : undefined
+                            )
+                            .catch(() => undefined),
+                    ]);
+                    return {
+                        ...attachment,
+                        size: Number(info.sizeBytes),
+                        type: info.mediaType,
+                        name: info.path,
+                        width: dimensions?.width,
+                        height: dimensions?.height,
+                        provider: "media",
+                    };
+                }
+                const metadata = await Attachments.get(opts.client, attachment.id as AttachmentRid);
                 return {
-                    ...attachment,
-                    size: Number(info.sizeBytes),
-                    type: info.mediaType,
-                    name: info.path,
+                    id: attachment.id,
+                    size: Number(metadata.sizeBytes),
+                    type: metadata.mediaType,
+                    name: metadata.filename,
+                    provider: "attachment",
                 };
+            } catch (error) {
+                throw normalizeFoundryError(error);
             }
-            const metadata = await Attachments.get(opts.client, attachment.id as AttachmentRid);
-            return {
-                id: attachment.id,
-                size: Number(metadata.sizeBytes),
-                type: metadata.mediaType,
-                name: metadata.filename,
-            };
         },
     };
 
@@ -220,10 +245,15 @@ export function createFoundryOntologyBackendAdapter(opts: {
                         getAttachmentProviderType(upload.target) === "media",
                         `Foundry attachment "${upload.attachment.id}" was not materialized before action execution.`
                     );
-                    const reference = await MediaSets.uploadMedia(opts.client, upload.blob, {
-                        filename: getAttachmentName(upload.attachment) ?? upload.attachment.id,
-                        preview: true,
-                    });
+                    let reference: Awaited<ReturnType<typeof MediaSets.uploadMedia>>;
+                    try {
+                        reference = await MediaSets.uploadMedia(opts.client, upload.blob, {
+                            filename: getAttachmentName(upload.attachment) ?? upload.attachment.id,
+                            preview: true,
+                        });
+                    } catch (error) {
+                        throw normalizeFoundryError(error);
+                    }
                     mediaReferences.set(upload.attachment.id, reference);
                     attachmentIdMappings.push({
                         localId: upload.attachment.id,
@@ -287,16 +317,27 @@ export function createFoundryOntologyBackendAdapter(opts: {
                     } as any
                 );
             } catch (error) {
-                if (isFoundryNotFoundError(error)) {
+                const normalized = normalizeFoundryError(error);
+                if (isFoundryNotFoundError(normalized)) {
                     throw new NonRetryableError(
-                        error instanceof Error ? error.message : "Foundry action target was not found.",
-                        { cause: error }
+                        normalized.message || "Foundry action target was not found.",
+                        { cause: normalized }
                     );
                 }
-                throw error;
+                throw normalized;
             }
             if (result.validation?.result === "INVALID") {
-                throw new NonRetryableError("Invalid Action arguments.");
+                const validationError = new FoundryActionValidationError(
+                    "Invalid Action arguments.",
+                    {
+                        statusCode: 400,
+                        validation: result.validation,
+                        parameters: { actionType: name },
+                    }
+                );
+                throw new NonRetryableError(validationError.message, {
+                    cause: validationError,
+                });
             }
             if (context) {
                 const operationId = getApplyActionOperationId(result);
@@ -330,13 +371,22 @@ export function createFoundryOntologyBackendAdapter(opts: {
                     : value;
             }
 
-            const result = await Queries.execute(opts.client, opts.client.ontologyRid, name, {
-                parameters: requestParameters,
-            });
+            try {
+                const result = await Queries.execute(opts.client, opts.client.ontologyRid, name, {
+                    parameters: requestParameters,
+                });
 
-            return codec.decodeValue(queryFunctionType.returnType, result.value);
+                return codec.decodeValue(queryFunctionType.returnType, result.value);
+            } catch (error) {
+                throw normalizeFoundryError(error);
+            }
         },
         attachments,
+        links: createFoundryLinksAdapter({
+            client: opts.client,
+            ir: opts.ir,
+            codec,
+        }),
     };
 }
 

--- a/packages/foundry-ontology/src/adapter/index.ts
+++ b/packages/foundry-ontology/src/adapter/index.ts
@@ -1,3 +1,4 @@
 export * from "./objectCollectionOptions.js";
 export * from "./createFoundryOntologyBackendAdapter.js";
+export * from "./createFoundryLinksAdapter.js";
 export * from "./foundryCodec.js";

--- a/packages/foundry-ontology/src/adapter/objectCollectionOptions.test.ts
+++ b/packages/foundry-ontology/src/adapter/objectCollectionOptions.test.ts
@@ -1,3 +1,4 @@
+import { FoundryError } from "@party-stack/foundry-client";
 import { o } from "@party-stack/ontology";
 import { eq, gt, IR, type LoadSubsetOptions } from "@tanstack/db";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -1169,6 +1170,31 @@ describe("objectCollectionOptions", () => {
         });
         expect([...harness.syncedData.keys()]).toEqual([3, 4]);
 
+        harness.cleanup();
+    });
+
+    it("normalizes Foundry search failures at the collection boundary", async () => {
+        mockState.search.mockRejectedValue({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+            errorName: "ObjectTypePermissionDenied",
+            message: "Not allowed to load Employee.",
+            parameters: { objectType: "Employee" },
+        });
+        const harness = createSyncHarness();
+
+        const error = await harness.loadSubset({}).then(
+            () => undefined,
+            (cause: unknown) => cause
+        );
+
+        expect(error).toBeInstanceOf(FoundryError);
+        expect(error).toMatchObject({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+            errorName: "ObjectTypePermissionDenied",
+            parameters: { objectType: "Employee" },
+        });
         harness.cleanup();
     });
 });

--- a/packages/foundry-ontology/src/adapter/objectCollectionOptions.ts
+++ b/packages/foundry-ontology/src/adapter/objectCollectionOptions.ts
@@ -6,6 +6,10 @@ import {
     ObjectTypesV2,
     type ObjectPrimaryKeyV2,
 } from "@osdk/foundry.ontologies";
+import {
+    normalizeFoundryError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
 import { getObjectSetWatcherManager } from "@party-stack/foundry-object-set-watcher";
 import {
     BasicIndex,
@@ -18,7 +22,6 @@ import {
     UtilsRecord,
 } from "@tanstack/db";
 import { Store } from "@tanstack/store";
-import type { OntologyClient } from "@party-stack/foundry-client";
 import * as AsyncIterable from "../utils/AsyncIterable.js";
 import {
     convertLoadSubsetFilter,
@@ -258,25 +261,30 @@ async function fetchFoundryObjects(
         }
     }
 
-    const results = await AsyncIterable.toArray(
-        AsyncIterable.fromPagination(
-            (pageSize, pageToken: string | undefined) =>
-                OntologyObjectsV2.search(client, client.ontologyRid, objectType, {
-                    snapshot: true,
-                    where,
-                    excludeRid: true,
-                    select: selectedProperties,
-                    selectV2: [],
-                    pageSize,
-                    pageToken,
-                    orderBy: convertLoadSubsetOrderBy(opts.orderBy),
-                }),
-            (page) => page.nextPageToken,
-            (page) => page.data,
-            10_000,
-            limit === undefined ? undefined : offset + limit
-        )
-    );
+    let results: OntologyObjectV2[];
+    try {
+        results = await AsyncIterable.toArray(
+            AsyncIterable.fromPagination(
+                (pageSize, pageToken: string | undefined) =>
+                    OntologyObjectsV2.search(client, client.ontologyRid, objectType, {
+                        snapshot: true,
+                        where,
+                        excludeRid: true,
+                        select: selectedProperties,
+                        selectV2: [],
+                        pageSize,
+                        pageToken,
+                        orderBy: convertLoadSubsetOrderBy(opts.orderBy),
+                    }),
+                (page) => page.nextPageToken,
+                (page) => page.data,
+                10_000,
+                limit === undefined ? undefined : offset + limit
+            )
+        );
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
 
     return (results as FoundryObject[])
         .slice(offset, limit === undefined ? undefined : offset + limit)
@@ -445,18 +453,25 @@ function createSyncConfig(
                 return true;
             };
 
-            const fetchEditHistoryPage = (body: Parameters<typeof ObjectTypesV2.getEditsHistory>[3]) =>
-                ObjectTypesV2.getEditsHistory(
-                    client,
-                    client.ontologyRid,
-                    objectType,
-                    body,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    {
-                        preview: true,
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    } as unknown as any
-                );
+            const fetchEditHistoryPage = async (
+                body: Parameters<typeof ObjectTypesV2.getEditsHistory>[3]
+            ) => {
+                try {
+                    return await ObjectTypesV2.getEditsHistory(
+                        client,
+                        client.ontologyRid,
+                        objectType,
+                        body,
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        {
+                            preview: true,
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        } as unknown as any
+                    );
+                } catch (error) {
+                    throw normalizeFoundryError(error);
+                }
+            };
 
             const decodeEditProperties = (
                 properties: Record<string, unknown>,
@@ -739,48 +754,50 @@ function createSyncConfig(
             };
 
             const loadSubsetDedupe = new DeduplicatedLoadSubset({ loadSubset });
-            const objectSetWatcherManager = getObjectSetWatcherManager(client);
-            const unsubscribe = objectSetWatcherManager.subscribe({ type: "base", objectType }, (message) => {
-                switch (message.type) {
-                    case "change": {
-                        if (
-                            editHistoryUnavailable
-                        ) {
-                            if (fullRefreshTask) {
-                                pendingDirectWatcherUpdates.push(...message.updates);
-                            } else {
-                                applyDirectWatcherUpdates(message.updates);
+            let unsubscribe: () => void;
+            try {
+                const objectSetWatcherManager = getObjectSetWatcherManager(client);
+                unsubscribe = objectSetWatcherManager.subscribe(
+                    { type: "base", objectType },
+                    (message) => {
+                        switch (message.type) {
+                            case "change": {
+                                if (editHistoryUnavailable) {
+                                    if (fullRefreshTask) {
+                                        pendingDirectWatcherUpdates.push(...message.updates);
+                                    } else {
+                                        applyDirectWatcherUpdates(message.updates);
+                                    }
+                                } else {
+                                    pendingDirectWatcherUpdates.push(...message.updates);
+                                    requestEditHistoryCatchUp?.();
+                                }
+                                break;
                             }
-                        } else {
-                            pendingDirectWatcherUpdates.push(...message.updates);
-                            requestEditHistoryCatchUp?.();
-                        }
-                        break;
-                    }
-                    case "refresh": {
-                        if (
-                            editHistoryUnavailable
-                        ) {
-                            requestFullRefresh?.();
-                        } else {
-                            requestEditHistoryCatchUp?.();
-                        }
-                        break;
-                    }
-                    case "state": {
-                        if (message.status === "open") {
-                            if (
-                                editHistoryUnavailable
-                            ) {
-                                requestFullRefresh?.();
-                            } else {
-                                requestEditHistoryCatchUp?.();
+                            case "refresh": {
+                                if (editHistoryUnavailable) {
+                                    requestFullRefresh?.();
+                                } else {
+                                    requestEditHistoryCatchUp?.();
+                                }
+                                break;
+                            }
+                            case "state": {
+                                if (message.status === "open") {
+                                    if (editHistoryUnavailable) {
+                                        requestFullRefresh?.();
+                                    } else {
+                                        requestEditHistoryCatchUp?.();
+                                    }
+                                }
+                                break;
                             }
                         }
-                        break;
                     }
-                }
-            });
+                );
+            } catch (error) {
+                throw normalizeFoundryError(error);
+            }
 
             // start task here, cleanup can stop it
             // in that task:

--- a/packages/foundry-ontology/src/meta/actionTypeCollectionOptions.test.ts
+++ b/packages/foundry-ontology/src/meta/actionTypeCollectionOptions.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from "vitest";
-import { isNotDeclarativeActionType } from "./actionTypeCollectionOptions.js";
+import {
+    FoundryError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
+import { and, eq, IR } from "@tanstack/db";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { isNotDeclarativeActionType, loadActionTypeCollectionRows } from "./actionTypeCollectionOptions.js";
 import type { ActionTypeV2 } from "@osdk/foundry.ontologies";
+
+const mocks = vi.hoisted(() => ({
+    getByRid: vi.fn(),
+    search: vi.fn(),
+    getFullMetadata: vi.fn(),
+}));
+
+vi.mock("@osdk/foundry.ontologies", () => ({
+    ActionTypesV2: {
+        getByRid: mocks.getByRid,
+        search: mocks.search,
+    },
+    ActionTypesFullMetadata: {
+        get: mocks.getFullMetadata,
+    },
+}));
 
 function actionType(overrides: Partial<ActionTypeV2> = {}): ActionTypeV2 {
     return {
@@ -12,6 +33,21 @@ function actionType(overrides: Partial<ActionTypeV2> = {}): ActionTypeV2 {
         ...overrides,
     };
 }
+
+function client(): OntologyClient {
+    return {
+        baseUrl: "https://foundry.example.com",
+        ontologyRid: "ri.ontology.main.ontology.example",
+        tokenProvider: () => Promise.resolve("token"),
+        fetch: globalThis.fetch,
+    };
+}
+
+beforeEach(() => {
+    mocks.getByRid.mockReset();
+    mocks.search.mockReset();
+    mocks.getFullMetadata.mockReset();
+});
 
 describe("isNotDeclarativeActionType", () => {
     it("treats empty operations as non-declarative", () => {
@@ -27,5 +63,172 @@ describe("isNotDeclarativeActionType", () => {
                 })
             )
         ).toBe(false);
+    });
+});
+
+describe("loadActionTypeCollectionRows RID pushdown", () => {
+    it("resolves eq(ActionType.id, rid) via getByRid then full metadata", async () => {
+        mocks.getByRid.mockResolvedValue({
+            apiName: "create-task",
+            displayName: "Create task",
+            status: "ACTIVE",
+            parameters: {},
+            rid: "ri.actions.main.action-type.create",
+            operations: [{ type: "createObject", objectTypeApiName: "Task" }],
+        });
+        mocks.getFullMetadata.mockResolvedValue({
+            actionType: {
+                apiName: "create-task",
+                displayName: "Create task",
+                status: "ACTIVE",
+                parameters: {},
+                rid: "ri.actions.main.action-type.create",
+                operations: [{ type: "createObject", objectTypeApiName: "Task" }],
+            },
+            fullLogicRules: [],
+        });
+
+        const rows = await loadActionTypeCollectionRows(client(), {
+            where: eq(new IR.PropRef<string>(["id"]), "ri.actions.main.action-type.create"),
+        });
+
+        expect(mocks.getByRid).toHaveBeenCalledWith(
+            expect.anything(),
+            "ri.ontology.main.ontology.example",
+            "ri.actions.main.action-type.create"
+        );
+        expect(mocks.search).not.toHaveBeenCalled();
+        expect(mocks.getFullMetadata).toHaveBeenCalledWith(
+            expect.anything(),
+            "ri.ontology.main.ontology.example",
+            "create-task",
+            { preview: true }
+        );
+        expect(rows).toEqual([
+            expect.objectContaining({
+                name: "createTask",
+                id: "ri.actions.main.action-type.create",
+                displayName: "Create task",
+            }),
+        ]);
+    });
+
+    it("uses search pushdown for displayName filters", async () => {
+        mocks.search.mockResolvedValue({
+            data: [
+                {
+                    apiName: "create-task",
+                    displayName: "Create task",
+                    status: "ACTIVE",
+                    parameters: {},
+                    rid: "ri.actions.main.action-type.create",
+                    operations: [],
+                },
+            ],
+            nextPageToken: undefined,
+        });
+
+        const rows = await loadActionTypeCollectionRows(client(), {
+            where: eq(new IR.PropRef<string>(["displayName"]), "Create task"),
+        });
+
+        expect(mocks.search).toHaveBeenCalled();
+        expect(mocks.getByRid).not.toHaveBeenCalled();
+        expect(mocks.getFullMetadata).not.toHaveBeenCalled();
+        expect(rows).toEqual([
+            expect.objectContaining({
+                name: "createTask",
+                id: "ri.actions.main.action-type.create",
+            }),
+        ]);
+    });
+
+    it("uses search pushdown for RID combined with another predicate", async () => {
+        mocks.search.mockResolvedValue({
+            data: [
+                {
+                    apiName: "create-task",
+                    displayName: "Create task",
+                    status: "ACTIVE",
+                    parameters: {},
+                    rid: "ri.actions.main.action-type.create",
+                    operations: [],
+                },
+            ],
+            nextPageToken: undefined,
+        });
+
+        const rows = await loadActionTypeCollectionRows(client(), {
+            where: and(
+                eq(
+                    new IR.PropRef<string>(["id"]),
+                    "ri.actions.main.action-type.create"
+                ),
+                eq(new IR.PropRef<string>(["name"]), "createTask")
+            ),
+        });
+
+        expect(mocks.getByRid).not.toHaveBeenCalled();
+        expect(mocks.search).toHaveBeenCalledWith(
+            expect.anything(),
+            "ri.ontology.main.ontology.example",
+            expect.objectContaining({
+                where: {
+                    type: "and",
+                    value: [
+                        {
+                            type: "actionTypeRid",
+                            value: "ri.actions.main.action-type.create",
+                        },
+                        {
+                            type: "actionTypeApiName",
+                            value: { type: "exact", value: "create-task" },
+                        },
+                    ],
+                },
+            }),
+            { preview: true }
+        );
+        expect(rows).toEqual([
+            expect.objectContaining({
+                id: "ri.actions.main.action-type.create",
+                name: "createTask",
+            }),
+        ]);
+    });
+
+    it("returns empty results for missing RID lookups", async () => {
+        mocks.getByRid.mockRejectedValue({
+            statusCode: 404,
+            errorCode: "NOT_FOUND",
+            message: "missing",
+        });
+
+        const rows = await loadActionTypeCollectionRows(client(), {
+            where: eq(new IR.PropRef<string>(["id"]), "ri.actions.main.action-type.missing"),
+        });
+
+        expect(rows).toEqual([]);
+    });
+
+    it("normalizes action search failures", async () => {
+        mocks.search.mockRejectedValue({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+            errorName: "ActionTypePermissionDenied",
+            message: "Not allowed to search actions.",
+        });
+
+        const error = await loadActionTypeCollectionRows(client()).then(
+            () => undefined,
+            (cause: unknown) => cause
+        );
+
+        expect(error).toBeInstanceOf(FoundryError);
+        expect(error).toMatchObject({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+            errorName: "ActionTypePermissionDenied",
+        });
     });
 });

--- a/packages/foundry-ontology/src/meta/actionTypeCollectionOptions.ts
+++ b/packages/foundry-ontology/src/meta/actionTypeCollectionOptions.ts
@@ -4,15 +4,16 @@ import {
     type ActionTypeFullMetadata,
     type ActionTypeV2,
 } from "@osdk/foundry.ontologies";
+import { normalizeFoundryError, type OntologyClient } from "@party-stack/foundry-client";
 import { QueryClient } from "@tanstack/query-core";
 import { queryCollectionOptions } from "@tanstack/query-db-collection";
-import type { OntologyClient } from "@party-stack/foundry-client";
 import type { MetaActionType, OntologyCollectionOptions } from "@party-stack/ontology";
 import * as AsyncIterable from "../utils/AsyncIterable.js";
 import {
     convertActionTypeLoadSubsetFilter,
     convertActionTypeLoadSubsetOrderBy,
 } from "./convertActionTypeLoadSubsetOptions.js";
+import { convertActionTypeRidQuery } from "./convertActionTypeRidQuery.js";
 import { convertFoundryMetaActionType } from "./convertMetaActionType.js";
 import type { LoadSubsetOptions } from "@tanstack/db";
 
@@ -26,6 +27,29 @@ export function isNotDeclarativeActionType(actionType: ActionTypeV2): boolean {
     return actionType.operations.length === 0;
 }
 
+async function getActionTypesByRid(client: OntologyClient, rids: string[]): Promise<ActionTypeV2[]> {
+    const uniqueRids = Array.from(new Set(rids));
+    if (uniqueRids.length === 0) {
+        return [];
+    }
+
+    const results = await Promise.all(
+        uniqueRids.map(async (rid) => {
+            try {
+                return await ActionTypesV2.getByRid(client, client.ontologyRid, rid);
+            } catch (error) {
+                const normalized = normalizeFoundryError(error);
+                if (normalized.statusCode === 404 || normalized.errorCode === "NOT_FOUND") {
+                    return undefined;
+                }
+                throw normalized;
+            }
+        })
+    );
+
+    return results.filter((actionType): actionType is ActionTypeV2 => actionType !== undefined);
+}
+
 async function searchActionTypes(
     client: OntologyClient,
     options?: LoadSubsetOptions
@@ -36,27 +60,32 @@ async function searchActionTypes(
     const offset = canPushDownPagination ? (options?.offset ?? 0) : 0;
     const limit = canPushDownPagination ? options?.limit : undefined;
 
-    const results = await AsyncIterable.toArray(
-        AsyncIterable.fromPagination(
-            (pageSize, pageToken: string | undefined) =>
-                ActionTypesV2.search(
-                    client,
-                    client.ontologyRid,
-                    {
-                        where,
-                        orderBy,
-                        pageSize,
-                        pageToken,
-                        fuzziness: { type: "off" },
-                    },
-                    { preview: true }
-                ),
-            (page) => page.nextPageToken,
-            (page) => page.data,
-            100,
-            limit === undefined ? undefined : offset + limit
-        )
-    );
+    let results: ActionTypeV2[];
+    try {
+        results = await AsyncIterable.toArray(
+            AsyncIterable.fromPagination(
+                (pageSize, pageToken: string | undefined) =>
+                    ActionTypesV2.search(
+                        client,
+                        client.ontologyRid,
+                        {
+                            where,
+                            orderBy,
+                            pageSize,
+                            pageToken,
+                            fuzziness: { type: "off" },
+                        },
+                        { preview: true }
+                    ),
+                (page) => page.nextPageToken,
+                (page) => page.data,
+                100,
+                limit === undefined ? undefined : offset + limit
+            )
+        );
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
 
     return results.slice(offset, limit === undefined ? undefined : offset + limit);
 }
@@ -72,7 +101,35 @@ async function loadActionTypeFullMetadata(
         };
     }
 
-    return ActionTypesFullMetadata.get(client, client.ontologyRid, actionType.apiName, { preview: true });
+    try {
+        return await ActionTypesFullMetadata.get(client, client.ontologyRid, actionType.apiName, {
+            preview: true,
+        });
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
+}
+
+/**
+ * Loads ActionType meta rows for a TanStack load-subset query.
+ *
+ * Exact `id` (RID) filters are resolved with `ActionTypesV2.getByRid`, then each resolved API
+ * name is hydrated with `ActionTypesFullMetadata.get`. Name/displayName filters continue to use
+ * the search endpoint pushdown.
+ */
+export async function loadActionTypeCollectionRows(
+    client: OntologyClient,
+    loadSubsetOptions?: LoadSubsetOptions
+): Promise<MetaActionType[]> {
+    const ridQuery = convertActionTypeRidQuery(loadSubsetOptions);
+    const actionTypes =
+        ridQuery.type === "byRid"
+            ? await getActionTypesByRid(client, ridQuery.rids)
+            : await searchActionTypes(client, loadSubsetOptions);
+    const actionTypeMetadata = await Promise.all(
+        actionTypes.map((actionType) => loadActionTypeFullMetadata(client, actionType))
+    );
+    return actionTypeMetadata.map(convertFoundryMetaActionType);
 }
 
 export function actionTypeCollectionOptions(opts: ActionTypeCollectionOpts): OntologyCollectionOptions {
@@ -81,12 +138,6 @@ export function actionTypeCollectionOptions(opts: ActionTypeCollectionOpts): Ont
         getKey: (row) => row.name,
         queryKey: ["foundry", "ontology", "actionTypes"],
         syncMode: "on-demand",
-        queryFn: async (ctx) => {
-            const actionTypes = await searchActionTypes(opts.client, ctx.meta?.loadSubsetOptions);
-            const actionTypeMetadata = await Promise.all(
-                actionTypes.map((actionType) => loadActionTypeFullMetadata(opts.client, actionType))
-            );
-            return actionTypeMetadata.map(convertFoundryMetaActionType);
-        },
+        queryFn: async (ctx) => loadActionTypeCollectionRows(opts.client, ctx.meta?.loadSubsetOptions),
     }) as unknown as OntologyCollectionOptions;
 }

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
@@ -6,6 +6,20 @@ import {
 } from "./convertActionTypeLoadSubsetOptions.js";
 
 describe("convertActionTypeLoadSubsetFilter", () => {
+    it("converts id equality to an exact RID predicate", () => {
+        const filter = convertActionTypeLoadSubsetFilter(
+            eq(
+                new IR.PropRef<string>(["id"]),
+                "ri.actions.main.action-type.create-task"
+            )
+        );
+
+        expect(filter).toEqual({
+            type: "actionTypeRid",
+            value: "ri.actions.main.action-type.create-task",
+        });
+    });
+
     it("converts name equality to an exact apiName predicate with kebab-case", () => {
         const filter = convertActionTypeLoadSubsetFilter(
             eq(new IR.PropRef<string>(["name"]), "streamlineCreateToken")
@@ -107,6 +121,32 @@ describe("convertActionTypeLoadSubsetFilter", () => {
                 {
                     type: "actionTypeDisplayName",
                     value: { type: "contains", value: "Task" },
+                },
+            ],
+        });
+    });
+
+    it("supports RID predicates combined with searchable fields", () => {
+        const filter = convertActionTypeLoadSubsetFilter(
+            and(
+                eq(
+                    new IR.PropRef<string>(["id"]),
+                    "ri.actions.main.action-type.create-task"
+                ),
+                eq(new IR.PropRef<string>(["name"]), "createTask")
+            )
+        );
+
+        expect(filter).toEqual({
+            type: "and",
+            value: [
+                {
+                    type: "actionTypeRid",
+                    value: "ri.actions.main.action-type.create-task",
+                },
+                {
+                    type: "actionTypeApiName",
+                    value: { type: "exact", value: "create-task" },
                 },
             ],
         });

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
@@ -8,6 +8,7 @@ import type {
 } from "@osdk/foundry.ontologies";
 
 const FILTER_FIELDS = {
+    id: "actionTypeRid",
     name: "actionTypeApiName",
     displayName: "actionTypeDisplayName",
 } as const satisfies Partial<Record<keyof MetaActionType, ActionTypeSearchJsonQueryV2["type"]>>;
@@ -26,6 +27,12 @@ function getFilterField(field: FieldPath): keyof typeof FILTER_FIELDS {
 
 function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
     const name = getFilterField(field);
+    if (name === "id") {
+        return {
+            type: "actionTypeRid",
+            value: value as string,
+        };
+    }
     return {
         type: FILTER_FIELDS[name],
         value: {
@@ -37,6 +44,9 @@ function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
 
 function like(field: FieldPath, value: string): ActionTypeSearchJsonQueryV2 {
     const name = getFilterField(field);
+    if (name === "id") {
+        throw new Error("Foundry ActionType search only supports exact filtering by id.");
+    }
     const terms = value.split("%").filter(Boolean);
     const queries: ActionTypeSearchJsonQueryV2[] = terms.map((term) => ({
         type: FILTER_FIELDS[name],

--- a/packages/foundry-ontology/src/meta/convertActionTypeRidQuery.test.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeRidQuery.test.ts
@@ -1,0 +1,45 @@
+import { and, eq, inArray, IR, like } from "@tanstack/db";
+import { describe, expect, it } from "vitest";
+import { convertActionTypeRidQuery } from "./convertActionTypeRidQuery.js";
+
+describe("convertActionTypeRidQuery", () => {
+    it("detects eq/inArray id lookups", () => {
+        expect(
+            convertActionTypeRidQuery({
+                where: eq(new IR.PropRef<string>(["id"]), "ri.actions.main.action-type.a"),
+            })
+        ).toEqual({
+            type: "byRid",
+            rids: ["ri.actions.main.action-type.a"],
+        });
+
+        expect(
+            convertActionTypeRidQuery({
+                where: inArray(new IR.PropRef<string>(["id"]), [
+                    "ri.actions.main.action-type.a",
+                    "ri.actions.main.action-type.b",
+                ]),
+            })
+        ).toEqual({
+            type: "byRid",
+            rids: ["ri.actions.main.action-type.a", "ri.actions.main.action-type.b"],
+        });
+    });
+
+    it("falls back to search for unsupported or mixed predicates", () => {
+        expect(
+            convertActionTypeRidQuery({
+                where: like(new IR.PropRef<string>(["displayName"]), "%Create%"),
+            })
+        ).toEqual({ type: "search" });
+
+        expect(
+            convertActionTypeRidQuery({
+                where: and(
+                    eq(new IR.PropRef<string>(["id"]), "ri.actions.main.action-type.a"),
+                    eq(new IR.PropRef<string>(["name"]), "createPost")
+                ),
+            })
+        ).toEqual({ type: "search" });
+    });
+});

--- a/packages/foundry-ontology/src/meta/convertActionTypeRidQuery.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeRidQuery.ts
@@ -1,0 +1,67 @@
+import { FieldPath, LoadSubsetOptions, parseWhereExpression } from "@tanstack/db";
+
+export type ActionTypeRidQuery =
+    | { type: "byRid"; rids: string[] }
+    | { type: "search" };
+
+/**
+ * Detects exact ActionType.id RID lookups so they can be resolved via
+ * `ActionTypesV2.getByRid` instead of the search endpoint (which cannot filter by RID).
+ *
+ * Only pure `eq` / `inArray` trees over `id` are pushed down. Mixed predicates fall back to search.
+ */
+export function convertActionTypeRidQuery(options?: LoadSubsetOptions): ActionTypeRidQuery {
+    if (!options?.where) {
+        return { type: "search" };
+    }
+
+    const ridQuery =
+        parseWhereExpression<ActionTypeRidQuery | undefined>(options.where, {
+            handlers: {
+                and: (...queries: Array<ActionTypeRidQuery | undefined>) => {
+                    const ridQueries = queries.filter(
+                        (query): query is Extract<ActionTypeRidQuery, { type: "byRid" }> =>
+                            query?.type === "byRid"
+                    );
+                    if (ridQueries.length === 0 || ridQueries.length !== queries.length) {
+                        return undefined;
+                    }
+                    return {
+                        type: "byRid",
+                        rids: Array.from(new Set(ridQueries.flatMap((query) => query.rids))),
+                    };
+                },
+                or: (...queries: Array<ActionTypeRidQuery | undefined>) => {
+                    const ridQueries = queries.filter(
+                        (query): query is Extract<ActionTypeRidQuery, { type: "byRid" }> =>
+                            query?.type === "byRid"
+                    );
+                    if (ridQueries.length === 0 || ridQueries.length !== queries.length) {
+                        return undefined;
+                    }
+                    return {
+                        type: "byRid",
+                        rids: Array.from(new Set(ridQueries.flatMap((query) => query.rids))),
+                    };
+                },
+                eq: (field: FieldPath, value: unknown) => {
+                    if (field.join(".") === "id" && typeof value === "string") {
+                        return { type: "byRid", rids: [value] };
+                    }
+                },
+                in: (field: FieldPath, values: unknown[]) => {
+                    if (field.join(".") === "id") {
+                        return {
+                            type: "byRid",
+                            rids: values
+                                .filter((candidate): candidate is string => typeof candidate === "string")
+                                .filter(Boolean),
+                        };
+                    }
+                },
+            },
+            onUnknownOperator: () => undefined,
+        }) ?? undefined;
+
+    return ridQuery?.type === "byRid" ? ridQuery : { type: "search" };
+}

--- a/packages/foundry-ontology/src/meta/convertMetaActionType.test.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaActionType.test.ts
@@ -147,4 +147,10 @@ describe("convertFoundryMetaActionType parameter validation", () => {
             value: { name: "PostalCode" },
         });
     });
+
+    it("maps Foundry action-type RID to id", () => {
+        const result = convertFoundryMetaActionType(actionType({}));
+        expect(result.id).toBe("ri.actions.main.action-type.example");
+        expect(result.name).toBe("validatedAction");
+    });
 });

--- a/packages/foundry-ontology/src/meta/convertMetaActionType.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaActionType.ts
@@ -483,6 +483,7 @@ export function convertFoundryMetaActionType(actionType: ActionTypeFullMetadata)
 
     return {
         name: toOntologyActionTypeName(actionType.actionType.apiName),
+        id: actionType.actionType.rid,
         displayName: actionType.actionType.displayName ?? actionType.actionType.apiName,
         description: actionType.actionType.description,
         deprecated:

--- a/packages/foundry-ontology/src/meta/convertMetaLinkType.test.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaLinkType.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { convertFoundryMetaLinkTypes } from "./convertMetaLinkType.js";
+import type { ObjectTypeFullMetadata } from "@osdk/foundry.ontologies";
+
+describe("convertFoundryMetaLinkTypes", () => {
+    it("preserves FK-backed links with per-side cardinality", () => {
+        const objectTypes = [
+            {
+                objectType: { apiName: "Employee" },
+                linkTypes: [
+                    {
+                        apiName: "department",
+                        displayName: "Department",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Department",
+                        cardinality: "ONE",
+                        foreignKeyPropertyApiName: "departmentId",
+                        linkTypeRid: "ri.ontology.main.link-type.employee-department",
+                        linkTypeId: "employee-department",
+                    },
+                ],
+            },
+            {
+                objectType: { apiName: "Department" },
+                linkTypes: [
+                    {
+                        apiName: "employees",
+                        displayName: "Employees",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Employee",
+                        cardinality: "MANY",
+                        linkTypeRid: "ri.ontology.main.link-type.employee-department",
+                        linkTypeId: "employee-department",
+                    },
+                ],
+            },
+        ] as unknown as ObjectTypeFullMetadata[];
+
+        expect(convertFoundryMetaLinkTypes(objectTypes)).toEqual([
+            {
+                id: "ri.ontology.main.link-type.employee-department",
+                source: {
+                    objectType: "Employee",
+                    name: "employees",
+                    displayName: "Employees",
+                    cardinality: "many",
+                },
+                target: {
+                    objectType: "Department",
+                    name: "department",
+                    displayName: "Department",
+                    cardinality: "one",
+                },
+                foreignKey: "departmentId",
+                cardinality: "many",
+            },
+        ]);
+    });
+
+    it("keeps non-FK bidirectional links without dropping them", () => {
+        const objectTypes = [
+            {
+                objectType: { apiName: "Post" },
+                linkTypes: [
+                    {
+                        apiName: "comments",
+                        displayName: "Comments",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Comment",
+                        cardinality: "MANY",
+                        linkTypeRid: "ri.ontology.main.link-type.post-comment",
+                        linkTypeId: "post-comment",
+                    },
+                ],
+            },
+            {
+                objectType: { apiName: "Comment" },
+                linkTypes: [
+                    {
+                        apiName: "post",
+                        displayName: "Post",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Post",
+                        cardinality: "ONE",
+                        linkTypeRid: "ri.ontology.main.link-type.post-comment",
+                        linkTypeId: "post-comment",
+                    },
+                ],
+            },
+        ] as unknown as ObjectTypeFullMetadata[];
+
+        expect(convertFoundryMetaLinkTypes(objectTypes)).toEqual([
+            {
+                id: "ri.ontology.main.link-type.post-comment",
+                source: {
+                    objectType: "Post",
+                    name: "post",
+                    displayName: "Post",
+                    cardinality: "one",
+                },
+                target: {
+                    objectType: "Comment",
+                    name: "comments",
+                    displayName: "Comments",
+                    cardinality: "many",
+                },
+                foreignKey: undefined,
+                cardinality: "one",
+            },
+        ]);
+    });
+});

--- a/packages/foundry-ontology/src/meta/convertMetaLinkType.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaLinkType.ts
@@ -1,15 +1,22 @@
-import { invariant } from "@bobbyfidz/panic";
 import type { MetaLinkType } from "@party-stack/ontology";
 import type { LinkTypeSideCardinality, LinkTypeSideV2, ObjectTypeFullMetadata } from "@osdk/foundry.ontologies";
 
+interface OwnedLinkTypeSide {
+    ownerObjectType: string;
+    side: LinkTypeSideV2;
+}
+
 export function convertFoundryMetaLinkTypes(objectTypes: ObjectTypeFullMetadata[]): MetaLinkType[] {
-    const sidesByRid = new Map<string, LinkTypeSideV2[]>();
+    const sidesByRid = new Map<string, OwnedLinkTypeSide[]>();
 
     for (const objectType of objectTypes) {
         for (const linkType of objectType.linkTypes) {
             const key = linkType.linkTypeRid;
             const sides = sidesByRid.get(key) ?? [];
-            sides.push(linkType);
+            sides.push({
+                ownerObjectType: objectType.objectType.apiName,
+                side: linkType,
+            });
             sidesByRid.set(key, sides);
         }
     }
@@ -19,38 +26,42 @@ export function convertFoundryMetaLinkTypes(objectTypes: ObjectTypeFullMetadata[
         .filter((linkType): linkType is MetaLinkType => linkType !== null);
 }
 
-function convertFoundryMetaLinkType(id: string, sides: LinkTypeSideV2[]): MetaLinkType | null {
+function convertFoundryMetaLinkType(id: string, sides: OwnedLinkTypeSide[]): MetaLinkType | null {
     if (sides.length !== 2) {
         return null;
     }
 
-    const source = sides.find((side) => side.foreignKeyPropertyApiName);
-    if (!source) {
+    const sourceEntry = sides.find(({ side }) => side.foreignKeyPropertyApiName) ?? sides[0];
+    const targetEntry = sides.find((entry) => entry !== sourceEntry);
+    if (!sourceEntry || !targetEntry) {
         return null;
     }
 
-    const target = sides.find((side) => side !== source);
-    if (!target) {
-        return null;
-    }
+    // Full metadata stores each outgoing link under its owner object type, while
+    // `side.objectTypeApiName` and the side name/cardinality describe the linked side.
+    // Canonical IR stores each role on the object type it represents, so the role
+    // metadata is intentionally taken from the opposite owner's outgoing entry.
+    const sourceRole = targetEntry.side;
+    const targetRole = sourceEntry.side;
+    const sourceCardinality = convertFoundryLinkCardinality(sourceRole.cardinality);
+    const targetCardinality = convertFoundryLinkCardinality(targetRole.cardinality);
 
     return {
         id,
         source: {
-            objectType: source.objectTypeApiName,
-            name: source.apiName,
-            displayName: source.displayName,
+            objectType: sourceEntry.ownerObjectType,
+            name: sourceRole.apiName,
+            displayName: sourceRole.displayName,
+            cardinality: sourceCardinality,
         },
         target: {
-            objectType: target.objectTypeApiName,
-            name: target.apiName,
-            displayName: target.displayName,
+            objectType: targetEntry.ownerObjectType,
+            name: targetRole.apiName,
+            displayName: targetRole.displayName,
+            cardinality: targetCardinality,
         },
-        foreignKey: (() => {
-            invariant(source.foreignKeyPropertyApiName, "Expected Foundry link foreign key.");
-            return source.foreignKeyPropertyApiName;
-        })(),
-        cardinality: convertFoundryLinkCardinality(source.cardinality),
+        foreignKey: sourceEntry.side.foreignKeyPropertyApiName,
+        cardinality: sourceCardinality,
     };
 }
 

--- a/packages/foundry-ontology/src/meta/convertMetaObjectType.test.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaObjectType.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { convertFoundryMetaObjectType } from "./convertMetaObjectType.js";
+import type { ObjectTypeFullMetadata } from "@osdk/foundry.ontologies";
+
+function objectType(): ObjectTypeFullMetadata {
+    return {
+        objectType: {
+            apiName: "Employee",
+            displayName: "Employee",
+            pluralDisplayName: "Employees",
+            status: "ACTIVE",
+            description: "An employee",
+            primaryKey: "id",
+            titleProperty: "fullName",
+            properties: {
+                id: {
+                    dataType: { type: "string" },
+                    rid: "ri.ontology.main.property.employee-id",
+                    status: { type: "active" },
+                    typeClasses: [],
+                },
+                fullName: {
+                    dataType: { type: "string" },
+                    rid: "ri.ontology.main.property.employee-name",
+                    displayName: "Full name",
+                    status: { type: "active" },
+                    typeClasses: [],
+                },
+            },
+            rid: "ri.ontology.main.object-type.employee",
+        },
+        linkTypes: [],
+        implementsInterfaces: [],
+        implementsInterfaces2: {},
+        sharedPropertyTypeMapping: {},
+    } as unknown as ObjectTypeFullMetadata;
+}
+
+describe("convertFoundryMetaObjectType", () => {
+    it("maps Foundry object-type RID to id and preserves titleProperty", () => {
+        const result = convertFoundryMetaObjectType(objectType());
+
+        expect(result).toMatchObject({
+            name: "Employee",
+            id: "ri.ontology.main.object-type.employee",
+            primaryKey: "id",
+            titleProperty: "fullName",
+            displayName: "Employee",
+            pluralDisplayName: "Employees",
+        });
+        expect(result.properties.map((property) => property.name)).toEqual(["id", "fullName"]);
+    });
+});

--- a/packages/foundry-ontology/src/meta/convertMetaObjectType.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaObjectType.ts
@@ -5,9 +5,11 @@ import type { ObjectTypeFullMetadata, PropertyV2 } from "@osdk/foundry.ontologie
 export function convertFoundryMetaObjectType(objectType: ObjectTypeFullMetadata): MetaObjectType {
     return {
         name: objectType.objectType.apiName,
+        id: objectType.objectType.rid,
         displayName: objectType.objectType.displayName,
         pluralDisplayName: objectType.objectType.pluralDisplayName,
         primaryKey: objectType.objectType.primaryKey,
+        titleProperty: objectType.objectType.titleProperty,
         description: objectType.objectType.description,
         properties: Object.entries(objectType.objectType.properties).map(([name, property]) =>
             convertFoundryObjectProperty(name, property)

--- a/packages/foundry-ontology/src/meta/entityCollectionOptions.ts
+++ b/packages/foundry-ontology/src/meta/entityCollectionOptions.ts
@@ -1,4 +1,5 @@
 import { OntologiesV2 } from "@osdk/foundry.ontologies";
+import { normalizeFoundryError } from "@party-stack/foundry-client";
 import {
     createCollection,
     eq,
@@ -43,24 +44,28 @@ export function createMetaEntityCollection(opts: MetaEntityStoreOpts) {
             queryKey: ["foundry", "ontology", "metadata"],
             syncMode: "eager",
             queryFn: async () => {
-                const loaded = await loadFoundryMetaOntology(opts.client);
-                return [
-                    ...loaded.objectTypes.map((entity) => ({
-                        entityType: "ObjectType" as const,
-                        entity,
-                        ...entity,
-                    })),
-                    ...loaded.valueTypes.map((entity) => ({
-                        entityType: "ValueType" as const,
-                        entity,
-                        ...entity,
-                    })),
-                    ...loaded.linkTypes.map((entity) => ({
-                        entityType: "LinkType" as const,
-                        entity,
-                        ...entity,
-                    })),
-                ];
+                try {
+                    const loaded = await loadFoundryMetaOntology(opts.client);
+                    return [
+                        ...loaded.objectTypes.map((entity) => ({
+                            entityType: "ObjectType" as const,
+                            entity,
+                            ...entity,
+                        })),
+                        ...loaded.valueTypes.map((entity) => ({
+                            entityType: "ValueType" as const,
+                            entity,
+                            ...entity,
+                        })),
+                        ...loaded.linkTypes.map((entity) => ({
+                            entityType: "LinkType" as const,
+                            entity,
+                            ...entity,
+                        })),
+                    ];
+                } catch (error) {
+                    throw normalizeFoundryError(error);
+                }
             },
         })
     );
@@ -92,6 +97,12 @@ export function linkTypeCollectionOptions(metadata: MetaEntityCollection): Ontol
     }) as unknown as OntologyCollectionOptions;
 }
 
+/**
+ * Object/link/value meta entities are loaded from a single shared
+ * `OntologiesV2.getFullMetadata` request (eager collection). Foundry has no narrower public API
+ * that returns the property/title/link detail Party Stack needs, so RID/name filters are applied
+ * by TanStack DB against this cached snapshot rather than a separate RID endpoint.
+ */
 async function loadFoundryMetaOntology(client: OntologyClient): Promise<{
     objectTypes: MetaObjectType[];
     valueTypes: MetaValueType[];

--- a/packages/foundry-ontology/src/meta/foundryPrivateApiUrls.test.ts
+++ b/packages/foundry-ontology/src/meta/foundryPrivateApiUrls.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { getOntologyMetadataBulkLoadEntitiesUrl } from "./foundryPrivateApiUrls.js";
+
+describe("foundryPrivateApiUrls", () => {
+    it("builds the OMS bulkLoadEntities URL from an install origin", () => {
+        expect(getOntologyMetadataBulkLoadEntitiesUrl("https://foundry.example.com/workspace").href).toBe(
+            "https://foundry.example.com/ontology-metadata/api/ontology/ontology/bulkLoadEntities"
+        );
+    });
+});

--- a/packages/foundry-ontology/src/meta/foundryPrivateApiUrls.ts
+++ b/packages/foundry-ontology/src/meta/foundryPrivateApiUrls.ts
@@ -1,0 +1,15 @@
+function normalizePath(path: string): string {
+    return path.replace(/^\/+/, "");
+}
+
+/** Builds a Foundry private/API URL from an install base URL without leaking OSDK client internals. */
+export function getFoundryPrivateApiUrl(baseUrl: string, path: string): URL {
+    return new URL(normalizePath(path), `${new URL(baseUrl).origin}/`);
+}
+
+export function getOntologyMetadataBulkLoadEntitiesUrl(baseUrl: string): URL {
+    return getFoundryPrivateApiUrl(
+        baseUrl,
+        "/ontology-metadata/api/ontology/ontology/bulkLoadEntities"
+    );
+}

--- a/packages/foundry-ontology/src/meta/foundryUnredactedActionType.test.ts
+++ b/packages/foundry-ontology/src/meta/foundryUnredactedActionType.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest";
+import type { OntologyClient } from "@party-stack/foundry-client";
+import { getFoundryUnredactedActionTypeMetadata } from "./foundryUnredactedActionType.js";
+
+describe("getFoundryUnredactedActionTypeMetadata", () => {
+    it("posts to OMS bulkLoadEntities and maps parameter validations", async () => {
+        const fetch = vi.fn(() =>
+            Promise.resolve(
+                new Response(
+                    JSON.stringify({
+                        actionTypes: [
+                            {
+                                actionType: {
+                                    rid: "ri.actions.main.action-type.example",
+                                    metadata: {
+                                        rid: "ri.actions.main.action-type.example",
+                                        apiName: "modify-task",
+                                    },
+                                    actionTypeLogic: {
+                                        validation: {
+                                            parameterValidations: {
+                                                title: {
+                                                    defaultValidation: {
+                                                        prefill: {
+                                                            type: "staticValue",
+                                                            staticValue: {
+                                                                type: "string",
+                                                                string: "Untitled",
+                                                            },
+                                                        },
+                                                    },
+                                                },
+                                            },
+                                        },
+                                        logic: { rules: [] },
+                                    },
+                                },
+                            },
+                        ],
+                    }),
+                    { status: 200, headers: { "Content-Type": "application/json" } }
+                )
+            )
+        );
+
+        const client: OntologyClient = {
+            baseUrl: "https://foundry.example.com",
+            ontologyRid: "ri.ontology.main.ontology.example",
+            tokenProvider: () => Promise.resolve("token"),
+            fetch: fetch as unknown as typeof globalThis.fetch,
+        };
+
+        const result = await getFoundryUnredactedActionTypeMetadata(
+            client,
+            "ri.actions.main.action-type.example"
+        );
+
+        expect(fetch).toHaveBeenCalledWith(
+            expect.objectContaining({
+                href: "https://foundry.example.com/ontology-metadata/api/ontology/ontology/bulkLoadEntities",
+            }),
+            expect.objectContaining({
+                method: "POST",
+                headers: expect.objectContaining({
+                    Authorization: "Bearer token",
+                }) as Record<string, string>,
+            })
+        );
+        expect(result).toEqual({
+            rid: "ri.actions.main.action-type.example",
+            apiName: "modify-task",
+            parameterValidations: {
+                title: {
+                    defaultValidation: {
+                        prefill: {
+                            type: "staticValue",
+                            staticValue: { type: "string", string: "Untitled" },
+                        },
+                    },
+                },
+            },
+            actionTypeLogic: {
+                validation: {
+                    parameterValidations: {
+                        title: {
+                            defaultValidation: {
+                                prefill: {
+                                    type: "staticValue",
+                                    staticValue: { type: "string", string: "Untitled" },
+                                },
+                            },
+                        },
+                    },
+                },
+                logic: { rules: [] },
+            },
+            metadata: {
+                rid: "ri.actions.main.action-type.example",
+                apiName: "modify-task",
+            },
+        });
+    });
+
+    it("returns undefined when OMS has no matching action type", async () => {
+        const client: OntologyClient = {
+            baseUrl: "https://foundry.example.com",
+            ontologyRid: "ri.ontology.main.ontology.example",
+            tokenProvider: () => Promise.resolve("token"),
+            fetch: (() =>
+                Promise.resolve(
+                    new Response(JSON.stringify({ actionTypes: [] }), {
+                        status: 200,
+                        headers: { "Content-Type": "application/json" },
+                    })
+                )) as typeof globalThis.fetch,
+        };
+
+        await expect(
+            getFoundryUnredactedActionTypeMetadata(client, "ri.actions.main.action-type.missing")
+        ).resolves.toBeUndefined();
+    });
+});

--- a/packages/foundry-ontology/src/meta/foundryUnredactedActionType.ts
+++ b/packages/foundry-ontology/src/meta/foundryUnredactedActionType.ts
@@ -1,0 +1,181 @@
+import { normalizeFoundryError, type OntologyClient } from "@party-stack/foundry-client";
+import { getOntologyMetadataBulkLoadEntitiesUrl } from "./foundryPrivateApiUrls.js";
+
+/**
+ * Party-owned view of Foundry OMS unredacted action-type metadata.
+ *
+ * Generic `MetaActionType` (via the ActionType collection / `pull()`) already covers portable
+ * declarative logic and public parameter types. Structures that only exist on the unredacted OMS
+ * wire — layout, submission criteria, and nested parameter validations/prefills — are exposed
+ * here as the explicit Foundry-specific escape hatch.
+ */
+export type FoundryActionStaticValue =
+    | { type: "string"; string: string }
+    | { type: "boolean"; boolean: boolean }
+    | { type: "integer"; integer: number }
+    | { type: "long"; long: number | string }
+    | { type: "double"; double: number }
+    | { type: "date"; date: string }
+    | { type: "timestamp"; timestamp: string }
+    | { type: "null" };
+
+export type FoundryActionParameterPrefill =
+    | { type: "staticValue"; staticValue: FoundryActionStaticValue }
+    | {
+          type: "objectParameterPropertyValue";
+          objectParameterPropertyValue: {
+              parameterId: string;
+              propertyTypeId: string;
+          };
+      }
+    | {
+          type: "objectQueryPrefill";
+          objectQueryPrefill: {
+              objectSet: Record<string, unknown>;
+          };
+      }
+    | { type: string; [key: string]: unknown };
+
+export interface FoundryActionParameterValidationNode {
+    /** Nested default validation block from OMS wire. */
+    defaultValidation?: FoundryActionParameterValidationNode;
+    validation?: {
+        allowedValues?: unknown;
+        defaultValue?: unknown;
+        [key: string]: unknown;
+    };
+    display?: {
+        prefill?: FoundryActionParameterPrefill | null;
+        [key: string]: unknown;
+    };
+    prefill?: FoundryActionParameterPrefill | null;
+    defaultValue?: unknown;
+    structFieldValidations?: Record<string, FoundryActionParameterValidationNode>;
+    [key: string]: unknown;
+}
+
+export interface FoundryUnredactedActionTypeMetadata {
+    rid: string;
+    /** Present when the OMS payload includes action metadata.apiName. */
+    apiName?: string;
+    parameterValidations: Record<string, FoundryActionParameterValidationNode>;
+    /**
+     * Remaining unredacted OMS `actionTypeLogic` payload (rules, submission criteria, etc.).
+     * Intentionally opaque — Streamline interprets shapes it understands.
+     */
+    actionTypeLogic?: Record<string, unknown>;
+    /** Remaining unredacted OMS `metadata` payload. */
+    metadata?: Record<string, unknown>;
+}
+
+type BulkLoadActionTypeEntry = {
+    actionType?: {
+        rid?: string;
+        metadata?: Record<string, unknown> & {
+            rid?: string;
+            apiName?: string;
+        };
+        actionTypeLogic?: Record<string, unknown> & {
+            validation?: {
+                parameterValidations?: Record<string, FoundryActionParameterValidationNode>;
+            };
+        };
+    };
+};
+
+type BulkLoadOntologyEntitiesResponse = {
+    actionTypes?: BulkLoadActionTypeEntry[];
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return value !== null && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : undefined;
+}
+
+/**
+ * Loads unredacted OMS action-type metadata by RID.
+ *
+ * Requires the `ontology:view-unredacted-action-type` scope. Uses OntologyClient's
+ * `baseUrl` / `tokenProvider` / `fetch` only — no OSDK private context access.
+ */
+export async function getFoundryUnredactedActionTypeMetadata(
+    client: OntologyClient,
+    actionTypeRid: string
+): Promise<FoundryUnredactedActionTypeMetadata | undefined> {
+    const url = getOntologyMetadataBulkLoadEntitiesUrl(client.baseUrl);
+    const token = await client.tokenProvider();
+
+    let response: Response;
+    try {
+        response = await client.fetch(url, {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+                Accept: "application/json",
+            },
+            body: JSON.stringify({
+                actionTypes: [{ rid: actionTypeRid, versionReference: undefined }],
+                datasourceTypes: [],
+                linkTypes: [],
+                objectTypes: [],
+                sharedPropertyTypes: [],
+                interfaceTypes: [],
+                typeGroups: [],
+            }),
+        });
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
+
+    if (response.status === 404) {
+        return undefined;
+    }
+
+    if (!response.ok) {
+        const body = await response.text().catch(() => undefined);
+        throw normalizeFoundryError({
+            statusCode: response.status,
+            errorCode: "FOUNDRY_OMS_ERROR",
+            errorName: "UnredactedActionTypeLoadFailed",
+            errorInstanceId: undefined,
+            parameters: {
+                actionTypeRid,
+                body,
+            },
+            message: `Failed to load unredacted action type metadata (${response.status})`,
+        });
+    }
+
+    let payload: BulkLoadOntologyEntitiesResponse;
+    try {
+        payload = (await response.json()) as BulkLoadOntologyEntitiesResponse;
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
+
+    const wire = payload.actionTypes?.[0]?.actionType;
+    if (!wire) {
+        return undefined;
+    }
+
+    const metadata = asRecord(wire.metadata);
+    const actionTypeLogic = asRecord(wire.actionTypeLogic);
+    const validation = asRecord(actionTypeLogic?.validation);
+    const parameterValidations = (validation?.parameterValidations ?? {}) as Record<
+        string,
+        FoundryActionParameterValidationNode
+    >;
+
+    return {
+        rid:
+            (typeof wire.rid === "string" && wire.rid) ||
+            (typeof metadata?.rid === "string" && metadata.rid) ||
+            actionTypeRid,
+        apiName: typeof metadata?.apiName === "string" ? metadata.apiName : undefined,
+        parameterValidations,
+        actionTypeLogic,
+        metadata,
+    };
+}

--- a/packages/foundry-ontology/src/meta/index.ts
+++ b/packages/foundry-ontology/src/meta/index.ts
@@ -2,3 +2,4 @@ export * from "./createFoundryMetaOntologyBackendAdapter.js";
 export * from "./convertMetaActionType.js";
 export * from "./entityCollectionOptions.js";
 export * from "./actionTypeCollectionOptions.js";
+export * from "./foundryUnredactedActionType.js";

--- a/packages/foundry-ontology/src/meta/queryFunctionTypeCollectionOptions.test.ts
+++ b/packages/foundry-ontology/src/meta/queryFunctionTypeCollectionOptions.test.ts
@@ -1,0 +1,76 @@
+import { FoundryError, type OntologyClient } from "@party-stack/foundry-client";
+import { eq, IR } from "@tanstack/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadQueryFunctionTypeCollectionRows } from "./queryFunctionTypeCollectionOptions.js";
+
+const mocks = vi.hoisted(() => ({
+    get: vi.fn(),
+    list: vi.fn(),
+}));
+
+vi.mock("@osdk/foundry.ontologies", () => ({
+    QueryTypes: {
+        get: mocks.get,
+        list: mocks.list,
+    },
+}));
+
+const client: OntologyClient = {
+    baseUrl: "https://foundry.example.com",
+    ontologyRid: "ri.ontology.main.ontology.example",
+    tokenProvider: () => Promise.resolve("token"),
+    fetch: globalThis.fetch,
+};
+
+beforeEach(() => {
+    mocks.get.mockReset();
+    mocks.list.mockReset();
+});
+
+describe("loadQueryFunctionTypeCollectionRows", () => {
+    it("normalizes list failures", async () => {
+        mocks.list.mockRejectedValue({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+            message: "Not allowed to list query types.",
+        });
+
+        const error = await loadQueryFunctionTypeCollectionRows({ client }).then(
+            () => undefined,
+            (cause: unknown) => cause
+        );
+
+        expect(error).toBeInstanceOf(FoundryError);
+        expect(error).toMatchObject({
+            statusCode: 403,
+            errorCode: "PERMISSION_DENIED",
+        });
+    });
+
+    it("normalizes exact-name lookup failures", async () => {
+        mocks.get.mockRejectedValue({
+            statusCode: 404,
+            errorCode: "NOT_FOUND",
+            message: "Query type missing.",
+        });
+
+        const error = await loadQueryFunctionTypeCollectionRows(
+            { client },
+            {
+                where: eq(
+                    new IR.PropRef<string>(["name"]),
+                    "googleMapsAutocompleteAddress"
+                ),
+            }
+        ).then(
+            () => undefined,
+            (cause: unknown) => cause
+        );
+
+        expect(error).toBeInstanceOf(FoundryError);
+        expect(error).toMatchObject({
+            statusCode: 404,
+            errorCode: "NOT_FOUND",
+        });
+    });
+});

--- a/packages/foundry-ontology/src/meta/queryFunctionTypeCollectionOptions.ts
+++ b/packages/foundry-ontology/src/meta/queryFunctionTypeCollectionOptions.ts
@@ -1,8 +1,11 @@
 import { QueryTypes } from "@osdk/foundry.ontologies";
+import {
+    normalizeFoundryError,
+    type OntologyClient,
+} from "@party-stack/foundry-client";
 import { FieldPath, LoadSubsetOptions, parseWhereExpression } from "@tanstack/db";
 import { QueryClient } from "@tanstack/query-core";
 import { queryCollectionOptions } from "@tanstack/query-db-collection";
-import type { OntologyClient } from "@party-stack/foundry-client";
 import type { OntologyCollectionOptions, QueryFunctionTypeDef } from "@party-stack/ontology";
 import * as AsyncIterable from "../utils/AsyncIterable.js";
 import { convertFoundryMetaQueryFunctionType } from "./convertMetaQueryFunctionType.js";
@@ -14,26 +17,34 @@ export interface QueryFunctionTypeCollectionOpts {
 }
 
 async function listQueryFunctionTypes(opts: QueryFunctionTypeCollectionOpts): Promise<QueryTypeV2[]> {
-    return AsyncIterable.toArray(
-        AsyncIterable.fromPagination(
-            (pageSize, pageToken: string | undefined) =>
-                QueryTypes.list(opts.client, opts.client.ontologyRid, {
-                    pageSize,
-                    pageToken,
-                }),
-            (page) => page.nextPageToken,
-            (page) => page.data,
-            100
-        )
-    );
+    try {
+        return await AsyncIterable.toArray(
+            AsyncIterable.fromPagination(
+                (pageSize, pageToken: string | undefined) =>
+                    QueryTypes.list(opts.client, opts.client.ontologyRid, {
+                        pageSize,
+                        pageToken,
+                    }),
+                (page) => page.nextPageToken,
+                (page) => page.data,
+                100
+            )
+        );
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
 }
 
 async function getQueryFunctionTypes(opts: QueryFunctionTypeCollectionOpts, names: string[]): Promise<QueryTypeV2[]> {
     const uniqueNames = Array.from(new Set(names));
     if (uniqueNames.length === 0) return [];
-    return Promise.all(
-        uniqueNames.map((name) => QueryTypes.get(opts.client, opts.client.ontologyRid, name))
-    );
+    try {
+        return await Promise.all(
+            uniqueNames.map((name) => QueryTypes.get(opts.client, opts.client.ontologyRid, name))
+        );
+    } catch (error) {
+        throw normalizeFoundryError(error);
+    }
 }
 
 export function queryFunctionTypeCollectionOptions(opts: QueryFunctionTypeCollectionOpts): OntologyCollectionOptions {
@@ -42,14 +53,8 @@ export function queryFunctionTypeCollectionOptions(opts: QueryFunctionTypeCollec
         getKey: (row: { name: string }) => row.name,
         queryKey: ["foundry", "ontology", "queryFunctionTypes"],
         syncMode: "on-demand",
-        queryFn: async (ctx): Promise<QueryFunctionTypeDef[]> => {
-            const query = convertQueryFunctionTypeQuery(ctx.meta?.loadSubsetOptions);
-            const queryFunctionTypes =
-                query.type === "getBatch"
-                    ? await getQueryFunctionTypes(opts, query.names)
-                    : await listQueryFunctionTypes(opts);
-            return queryFunctionTypes.map(convertFoundryMetaQueryFunctionType);
-        },
+        queryFn: async (ctx): Promise<QueryFunctionTypeDef[]> =>
+            loadQueryFunctionTypeCollectionRows(opts, ctx.meta?.loadSubsetOptions),
     }) as unknown as OntologyCollectionOptions;
 }
 
@@ -83,4 +88,16 @@ function convertQueryFunctionTypeQuery(options?: LoadSubsetOptions): QueryFuncti
         }) ?? undefined;
 
     return batchQuery ?? { type: "list" };
+}
+
+export async function loadQueryFunctionTypeCollectionRows(
+    opts: QueryFunctionTypeCollectionOpts,
+    options?: LoadSubsetOptions
+): Promise<QueryFunctionTypeDef[]> {
+    const query = convertQueryFunctionTypeQuery(options);
+    const queryFunctionTypes =
+        query.type === "getBatch"
+            ? await getQueryFunctionTypes(opts, query.names)
+            : await listQueryFunctionTypes(opts);
+    return queryFunctionTypes.map(convertFoundryMetaQueryFunctionType);
 }

--- a/packages/ontology/src/cli/pull.test.ts
+++ b/packages/ontology/src/cli/pull.test.ts
@@ -1,0 +1,100 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { o } from "../ir/index.js";
+import { createStaticMetaOntologyBackendAdapter } from "../meta/createStaticMetaOntologyBackend.js";
+import { writePulledOntology } from "./pull.js";
+import type { OntologyIR } from "../ir/index.js";
+import type { OntologyConfig } from "../OntologyConfig.js";
+
+const fixtureIr: OntologyIR = {
+    types: [],
+    objectTypes: [
+        {
+            name: "Task",
+            id: "ri.ontology.main.object-type.task",
+            displayName: "Task",
+            pluralDisplayName: "Tasks",
+            primaryKey: "id",
+            titleProperty: "title",
+            properties: [
+                { name: "id", displayName: "ID", type: o.string({}) },
+                { name: "title", displayName: "Title", type: o.string({}) },
+            ],
+        },
+    ],
+    linkTypes: [],
+    actionTypes: [
+        {
+            name: "createTask",
+            id: "ri.actions.main.action-type.create-task",
+            displayName: "Create Task",
+            parameters: [{ name: "title", displayName: "Title", type: o.string({}) }],
+            logic: [],
+        },
+    ],
+    queryFunctionTypes: [],
+};
+
+describe("writePulledOntology", () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+        for (const dir of tempDirs.splice(0)) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+
+    it("writes a generated ontology module and cleans up the meta ontology", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "party-stack-pull-"));
+        tempDirs.push(dir);
+        const outPath = join(dir, "ontology.ts");
+
+        const config: OntologyConfig = {
+            adapter: {
+                createAdapter: () => createStaticMetaOntologyBackendAdapter({ ir: fixtureIr }),
+            },
+            opts: {},
+            objectTypeNames: ["Task"],
+            actionTypeNames: ["createTask"],
+            queryFunctionTypeNames: [],
+        };
+
+        await writePulledOntology(config, outPath, "@party-stack/ontology");
+
+        const contents = readFileSync(outPath, "utf-8");
+        expect(contents).toContain("Auto-generated file");
+        expect(contents).toContain("Task");
+        expect(contents).toContain("createTask");
+        expect(contents).toContain("titleProperty");
+    });
+
+    it("cleans up even when generation fails", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "party-stack-pull-fail-"));
+        tempDirs.push(dir);
+        const outPath = join(dir, "readonly", "ontology.ts");
+        writeFileSync(join(dir, "readonly"), "not-a-directory");
+
+        let cleanedUp = false;
+        const config: OntologyConfig = {
+            adapter: {
+                createAdapter: () => {
+                    const adapter = createStaticMetaOntologyBackendAdapter({ ir: fixtureIr });
+                    return {
+                        ...adapter,
+                        cleanup: () => {
+                            cleanedUp = true;
+                        },
+                    };
+                },
+            },
+            opts: {},
+            objectTypeNames: ["Task"],
+            actionTypeNames: [],
+        };
+
+        await expect(writePulledOntology(config, outPath)).rejects.toThrow();
+        expect(cleanedUp).toBe(true);
+    });
+});

--- a/packages/ontology/src/generate/ontology.ts
+++ b/packages/ontology/src/generate/ontology.ts
@@ -262,9 +262,17 @@ function renderProperty(property: PropertyDef): string {
 function renderObjectType(objectType: ObjectTypeDef): string {
     return renderObject([
         { name: "name", value: renderPlainValue(objectType.name) },
+        {
+            name: "id",
+            value: objectType.id ? renderPlainValue(objectType.id) : undefined,
+        },
         { name: "displayName", value: renderPlainValue(objectType.displayName) },
         { name: "pluralDisplayName", value: renderPlainValue(objectType.pluralDisplayName) },
         { name: "primaryKey", value: renderPlainValue(objectType.primaryKey) },
+        {
+            name: "titleProperty",
+            value: objectType.titleProperty ? renderPlainValue(objectType.titleProperty) : undefined,
+        },
         {
             name: "properties",
             value: withWriter((writer) =>
@@ -287,6 +295,10 @@ function renderLinkTypeSide(side: LinkTypeSideDef): string {
         { name: "objectType", value: renderPlainValue(side.objectType) },
         { name: "name", value: renderPlainValue(side.name) },
         { name: "displayName", value: renderPlainValue(side.displayName) },
+        {
+            name: "cardinality",
+            value: side.cardinality ? renderPlainValue(side.cardinality) : undefined,
+        },
     ]);
 }
 
@@ -295,7 +307,10 @@ function renderLinkType(linkType: LinkTypeDef): string {
         { name: "id", value: renderPlainValue(linkType.id) },
         { name: "source", value: renderLinkTypeSide(linkType.source) },
         { name: "target", value: renderLinkTypeSide(linkType.target) },
-        { name: "foreignKey", value: renderPlainValue(linkType.foreignKey) },
+        {
+            name: "foreignKey",
+            value: linkType.foreignKey ? renderPlainValue(linkType.foreignKey) : undefined,
+        },
         { name: "cardinality", value: renderPlainValue(linkType.cardinality) },
     ]);
 }
@@ -314,6 +329,10 @@ function renderActionPropertyAssignment(assignment: PropertyAssignment, ctx?: Re
 function renderActionType(actionType: ActionTypeDef, ctx?: RenderContext): string {
     return renderObject([
         { name: "name", value: renderPlainValue(actionType.name) },
+        {
+            name: "id",
+            value: actionType.id ? renderPlainValue(actionType.id) : undefined,
+        },
         { name: "displayName", value: renderPlainValue(actionType.displayName) },
         {
             name: "parameters",

--- a/packages/ontology/src/index.ts
+++ b/packages/ontology/src/index.ts
@@ -4,6 +4,7 @@ export * from "./live/index.js";
 export * from "./OntologyConfig.js";
 export type { OntologyObject } from "./live/objects/OntologyObject.js";
 export * from "./meta/pull.js";
+export * from "./meta/createStaticMetaOntologyBackend.js";
 export type {
     MetaOntology,
     LinkType as MetaLinkType,

--- a/packages/ontology/src/ir/generated/types.ts
+++ b/packages/ontology/src/ir/generated/types.ts
@@ -180,11 +180,15 @@ export type PropertyDef = {
 export type ObjectTypeDef = {
     /** The object type's programmatic name. */
     name: string;
+    /** Optional backend-neutral identifier for the object type. Foundry adapters map the object-type RID into this field. */
+    id?: string;
     /** Human-readable name. */
     displayName: string;
     pluralDisplayName: string;
     /** The name of the property that serves as primary key. */
     primaryKey: string;
+    /** Optional property used as the human-readable title/label for instances of this object type. */
+    titleProperty?: string;
     /** The object type's propertieo. */
     properties: Array<PropertyDef>;
     /** Optional description. */
@@ -196,6 +200,8 @@ export type LinkTypeSideDef = {
     objectType: string;
     name: string;
     displayName: string;
+    /** How many objects on this side participate in the link. */
+    cardinality?: "one" | "many";
 };
 
 /** The cardinality of a link from the source's perspective. */
@@ -206,9 +212,9 @@ export type LinkTypeDef = {
     id: string;
     source: LinkTypeSideDef;
     target: LinkTypeSideDef;
-    /** The foreign key on the source. */
-    foreignKey: string;
-    /** How many sources are linked to the target. */
+    /** Optional foreign key on the source. When omitted, traversal requires a backend link capability. */
+    foreignKey?: string;
+    /** How many sources are linked to the target. Prefer source.cardinality when present. */
     cardinality: "one" | "many";
 };
 
@@ -297,6 +303,8 @@ export type ActionLogicStep = v.Union<{
 export type ActionTypeDef = {
     /** The object type's programmatic name. */
     name: string;
+    /** Optional backend-neutral identifier for the action type. Foundry adapters map the action-type RID into this field. */
+    id?: string;
     /** Human-readable name. */
     displayName: string;
     /** The action type's parametero. */

--- a/packages/ontology/src/ir/schema.ts
+++ b/packages/ontology/src/ir/schema.ts
@@ -416,6 +416,13 @@ export default {
                         description: "The object type's programmatic name.",
                     },
                     {
+                        name: "id",
+                        displayName: "ID",
+                        type: o.optional({ type: o.string({}) }),
+                        description:
+                            "Optional backend-neutral identifier for the object type. Foundry adapters map the object-type RID into this field.",
+                    },
+                    {
                         name: "displayName",
                         displayName: "Display name",
                         type: o.string({}),
@@ -431,6 +438,13 @@ export default {
                         displayName: "Primary key",
                         type: o.string({}),
                         description: "The name of the property that serves as primary key.",
+                    },
+                    {
+                        name: "titleProperty",
+                        displayName: "Title property",
+                        type: o.optional({ type: o.string({}) }),
+                        description:
+                            "Optional property used as the human-readable title/label for instances of this object type.",
                     },
                     {
                         name: "properties",
@@ -471,6 +485,21 @@ export default {
                         displayName: "Display name",
                         type: o.string({}),
                     },
+                    {
+                        name: "cardinality",
+                        displayName: "Cardinality",
+                        type: o.optional({
+                            type: o.string({
+                                constraint: o.StringConstraint.enum({
+                                    options: [
+                                        { value: "one", label: "One" },
+                                        { value: "many", label: "Many" },
+                                    ],
+                                }),
+                            }),
+                        }),
+                        description: "How many objects on this side participate in the link.",
+                    },
                 ],
             }),
         },
@@ -509,8 +538,9 @@ export default {
                     {
                         name: "foreignKey",
                         displayName: "Foreign key",
-                        type: o.string({}),
-                        description: "The foreign key on the source.",
+                        type: o.optional({ type: o.string({}) }),
+                        description:
+                            "Optional foreign key on the source. When omitted, traversal requires a backend link capability.",
                     },
                     {
                         name: "cardinality",
@@ -523,7 +553,8 @@ export default {
                                 ],
                             }),
                         }),
-                        description: "How many sources are linked to the target.",
+                        description:
+                            "How many sources are linked to the target. Prefer source.cardinality when present.",
                     },
                 ],
             }),
@@ -756,6 +787,13 @@ export default {
                         displayName: "Name",
                         type: o.string({}),
                         description: "The object type's programmatic name.",
+                    },
+                    {
+                        name: "id",
+                        displayName: "ID",
+                        type: o.optional({ type: o.string({}) }),
+                        description:
+                            "Optional backend-neutral identifier for the action type. Foundry adapters map the action-type RID into this field.",
                     },
                     {
                         name: "displayName",

--- a/packages/ontology/src/live/LiveOntology.ts
+++ b/packages/ontology/src/live/LiveOntology.ts
@@ -8,6 +8,7 @@ import {
     type LiveOntologyAttachments,
 } from "./attachments/createLiveOntologyAttachments.js";
 import { unsupportedOntologyAttachmentsAdapter } from "./attachments/unsupportedOntologyAttachmentsAdapter.js";
+import { createLiveOntologyLinks, type LiveOntologyLinks } from "./links/createLiveOntologyLinks.js";
 import { createLiveOntologyObjectCollection } from "./objects/createLiveOntologyObjectCollection.js";
 import type { LiveOntologyAction } from "./actions/createLiveOntologyAction.js";
 import type { OntologyMutatorRegistry } from "./mutators/types.js";
@@ -21,6 +22,8 @@ import type { attachment } from "../utils/values.js";
 export type { LiveOntologyAction, LiveOntologyActionOptions } from "./actions/createLiveOntologyAction.js";
 export type { LiveOntologyAttachments } from "./attachments/createLiveOntologyAttachments.js";
 export type { OntologyCollection } from "./objects/createLiveOntologyObjectCollection.js";
+export type { LiveOntologyLinks } from "./links/createLiveOntologyLinks.js";
+export { OntologyLinkError } from "./links/resolveOntologyLink.js";
 
 export type LiveOntologyWriteMode = "direct" | "outbox";
 
@@ -85,6 +88,7 @@ export interface LiveOntology<Ontology extends OntologyDefinition = OntologyDefi
     objects: LiveOntologyObjects<Ontology["objectTypes"]>;
     actions: LiveOntologyActions<Ontology["actionTypes"]>;
     queryFunctions: LiveOntologyQueryFunctions<Ontology["queryFunctionTypes"]>;
+    links: LiveOntologyLinks;
     attachments: LiveOntologyAttachments;
     outbox: OntologyOutbox;
     cleanup: () => Promise<void>;
@@ -162,6 +166,11 @@ export async function createLiveOntology<
                 }),
         ])
     );
+    const links = createLiveOntologyLinks({
+        ir: opts.ir,
+        objects: objects as Record<string, Collection<Record<string, unknown>>>,
+        backendLinks: backendAdapter.links,
+    });
 
     return {
         ir: opts.ir,
@@ -170,6 +179,7 @@ export async function createLiveOntology<
         queryFunctions: queryFunctions as unknown as LiveOntologyQueryFunctions<
             Ontology["queryFunctionTypes"]
         >,
+        links,
         attachments,
         outbox: actionsSubsystem.outbox,
         cleanup: async () => {

--- a/packages/ontology/src/live/OntologyBackendAdapter.ts
+++ b/packages/ontology/src/live/OntologyBackendAdapter.ts
@@ -55,9 +55,62 @@ export interface OntologyAttachmentsAdapter {
         }
     ) => Promise<v.attachment | void>;
     getAttachmentContent: (attachment: v.attachment) => Promise<Blob>;
-    getAttachmentMetadata: (
-        attachment: v.attachment
-    ) => Promise<v.attachment & { size: number; type: string; name?: string }>;
+    getAttachmentMetadata: (attachment: v.attachment) => Promise<OntologyAttachmentMetadata>;
+}
+
+/**
+ * Attachment metadata returned by LiveOntology / backend adapters.
+ * Ordinary attachments remain compatible; media may include image dimensions.
+ */
+export type OntologyAttachmentMetadata = v.attachment & {
+    size: number;
+    type: string;
+    name?: string;
+    width?: number;
+    height?: number;
+    /** Which Foundry (or other) storage surface produced this attachment. */
+    provider?: "attachment" | "media";
+};
+
+export interface OntologyLinkedObject {
+    objectType: string;
+    primaryKey: string | number;
+    properties: Record<string, unknown>;
+}
+
+export interface OntologyLinkPage {
+    objects: OntologyLinkedObject[];
+    /** Opaque pagination token from the backend. */
+    nextPageToken?: string;
+}
+
+export type OntologyLinkRef = { sideName: string } | { id: string };
+
+export interface OntologyListLinksOpts {
+    objectType: string;
+    primaryKey: string | number;
+    link: OntologyLinkRef;
+    pageSize?: number;
+    pageToken?: string;
+    select?: string[];
+}
+
+export interface OntologyGetLinkOpts {
+    objectType: string;
+    primaryKey: string | number;
+    link: OntologyLinkRef;
+    /** When known, enables direct linked-object fetch on backends that support it. */
+    linkedPrimaryKey?: string | number;
+    select?: string[];
+}
+
+/**
+ * Optional backend capability for link traversal when the IR cannot satisfy the
+ * request locally (e.g. non-FK Foundry links).
+ */
+export interface OntologyLinksAdapter {
+    list: (opts: OntologyListLinksOpts) => Promise<OntologyLinkPage>;
+    get: (opts: OntologyGetLinkOpts) => Promise<OntologyLinkedObject | undefined>;
 }
 
 export interface OntologyBackendAdapter {
@@ -74,6 +127,8 @@ export interface OntologyBackendAdapter {
         live: RunQueryLiveOpts
     ) => Promise<unknown>;
     attachments?: OntologyAttachmentsAdapter;
+    /** Backend link traversal used when local FK resolution is not possible. */
+    links?: OntologyLinksAdapter;
     cleanup?: () => void | Promise<void>;
     // TODO: install/destroy
 }

--- a/packages/ontology/src/live/attachments/createLiveOntologyAttachments.ts
+++ b/packages/ontology/src/live/attachments/createLiveOntologyAttachments.ts
@@ -4,7 +4,7 @@ import { getTargetValueType } from "../../utils/types.js";
 import * as v from "../../utils/values.js";
 import type { OntologyIR } from "../../ir/index.js";
 import type { OntologyAttachmentCreateTarget } from "../../utils/targets.js";
-import type { OntologyAttachmentsAdapter } from "../OntologyBackendAdapter.js";
+import type { OntologyAttachmentsAdapter, OntologyAttachmentMetadata } from "../OntologyBackendAdapter.js";
 
 export interface LiveOntologyEagerAttachmentCreation {
     attachment: v.attachment;
@@ -25,9 +25,7 @@ export interface LiveOntologyAttachments {
         blob: Blob | File,
         opts?: Options
     ) => Promise<LiveOntologyAttachmentCreateResult<Options>>;
-    metadata: (
-        attachment: v.attachment
-    ) => Promise<v.attachment & { size: number; type: string; name?: string }>;
+    metadata: (attachment: v.attachment) => Promise<OntologyAttachmentMetadata>;
     blob: (attachment: v.attachment) => Promise<Blob>;
 }
 
@@ -93,6 +91,8 @@ export function createLiveOntologyAttachments(opts: {
 
     return {
         create,
+        // TODO: Remote ontology attachment metadata should bypass or extend BlobManager's
+        // reduced cached metadata shape so width/height/provider/source survive after blob reads.
         metadata: (attachment) =>
             blobManager.metadata(attachment.id, {
                 meta: { source: attachment.source },

--- a/packages/ontology/src/live/index.ts
+++ b/packages/ontology/src/live/index.ts
@@ -3,3 +3,5 @@ export * from "./LiveOntology.js";
 export * from "./mutators/types.js";
 export * from "./mutators/runOptimisticAction.js";
 export * from "./outbox/types.js";
+export * from "./links/createLiveOntologyLinks.js";
+export * from "./links/resolveOntologyLink.js";

--- a/packages/ontology/src/live/links/createLiveOntologyLinks.test.ts
+++ b/packages/ontology/src/live/links/createLiveOntologyLinks.test.ts
@@ -1,0 +1,242 @@
+import { BasicIndex, createCollection, type Collection } from "@tanstack/db";
+import { describe, expect, it, vi } from "vitest";
+import { o } from "../../ir/index.js";
+import { createLiveOntologyLinks } from "./createLiveOntologyLinks.js";
+import { OntologyLinkError } from "./resolveOntologyLink.js";
+import type { OntologyIR } from "../../ir/index.js";
+
+const ir: OntologyIR = {
+    types: [],
+    objectTypes: [
+        {
+            name: "Employee",
+            displayName: "Employee",
+            pluralDisplayName: "Employees",
+            primaryKey: "id",
+            properties: [
+                { name: "id", displayName: "Id", type: o.string({}) },
+                { name: "departmentId", displayName: "Department", type: o.string({}) },
+            ],
+        },
+        {
+            name: "Department",
+            displayName: "Department",
+            pluralDisplayName: "Departments",
+            primaryKey: "id",
+            properties: [{ name: "id", displayName: "Id", type: o.string({}) }],
+        },
+    ],
+    linkTypes: [
+        {
+            id: "ri.link.employee-department",
+            source: {
+                objectType: "Employee",
+                name: "employees",
+                displayName: "Employees",
+                cardinality: "many",
+            },
+            target: {
+                objectType: "Department",
+                name: "department",
+                displayName: "Department",
+                cardinality: "one",
+            },
+            foreignKey: "departmentId",
+            cardinality: "many",
+        },
+        {
+            id: "ri.link.non-fk",
+            source: {
+                objectType: "Employee",
+                name: "peerOf",
+                displayName: "Peer of",
+                cardinality: "many",
+            },
+            target: {
+                objectType: "Employee",
+                name: "peers",
+                displayName: "Peers",
+                cardinality: "many",
+            },
+            cardinality: "many",
+        },
+    ],
+    actionTypes: [],
+    queryFunctionTypes: [],
+};
+
+function memoryCollection(
+    rows: Record<string, unknown>[],
+    primaryKey: string,
+    loadSubset = vi.fn()
+): Collection<Record<string, unknown>> {
+    let loaded = false;
+    return createCollection<Record<string, unknown>>({
+        getKey: (row) => row[primaryKey] as string | number,
+        defaultIndexType: BasicIndex,
+        autoIndex: "eager" as const,
+        syncMode: "on-demand",
+        sync: {
+            sync: ({ begin, write, commit, markReady }) => {
+                markReady();
+                return {
+                    loadSubset: () => {
+                        loadSubset();
+                        if (loaded) return true;
+                        loaded = true;
+                        begin();
+                        for (const row of rows) {
+                            write({ type: "insert", value: row });
+                        }
+                        commit();
+                        return true;
+                    },
+                    cleanup: () => undefined,
+                };
+            },
+        },
+    });
+}
+
+describe("createLiveOntologyLinks", () => {
+    it("follows FK one/one and reverse one/many locally", async () => {
+        const loadEmployees = vi.fn();
+        const loadDepartments = vi.fn();
+        const employees = memoryCollection(
+            [
+                { id: "e1", name: "Ada", departmentId: "d1" },
+                { id: "e2", name: "Grace", departmentId: "d1" },
+                { id: "e3", name: "Linus", departmentId: "d2" },
+            ],
+            "id",
+            loadEmployees
+        );
+        const departments = memoryCollection(
+            [
+                { id: "d1", name: "Eng" },
+                { id: "d2", name: "Sales" },
+            ],
+            "id",
+            loadDepartments
+        );
+
+        const links = createLiveOntologyLinks({
+            ir,
+            objects: {
+                Employee: employees,
+                Department: departments,
+            },
+        });
+
+        await expect(
+            links.get({ objectType: "Employee", primaryKey: "e1", link: "department" })
+        ).resolves.toEqual({
+            objectType: "Department",
+            primaryKey: "d1",
+            properties: { id: "d1", name: "Eng" },
+        });
+        expect(loadEmployees).toHaveBeenCalled();
+        expect(loadDepartments).toHaveBeenCalled();
+
+        const firstPage = await links.list({
+            objectType: "Department",
+            primaryKey: "d1",
+            link: "employees",
+            pageSize: 1,
+            select: ["name"],
+        });
+        expect(firstPage).toEqual({
+            objects: [
+                {
+                    objectType: "Employee",
+                    primaryKey: "e1",
+                    properties: { id: "e1", name: "Ada" },
+                },
+            ],
+            nextPageToken: "local-fk:1",
+        });
+        await expect(
+            links.list({
+                objectType: "Department",
+                primaryKey: "d1",
+                link: "employees",
+                pageSize: 1,
+                pageToken: firstPage.nextPageToken,
+                select: ["name"],
+            })
+        ).resolves.toEqual({
+            objects: [
+                {
+                    objectType: "Employee",
+                    primaryKey: "e2",
+                    properties: { id: "e2", name: "Grace" },
+                },
+            ],
+            nextPageToken: undefined,
+        });
+
+        await expect(
+            links.get({
+                objectType: "Department",
+                primaryKey: "d1",
+                link: "employees",
+                linkedPrimaryKey: "e2",
+                select: ["name"],
+            })
+        ).resolves.toEqual({
+            objectType: "Employee",
+            primaryKey: "e2",
+            properties: { id: "e2", name: "Grace" },
+        });
+    });
+
+    it("falls back to the backend for non-FK links", async () => {
+        const backendList = vi.fn(() =>
+            Promise.resolve({
+                objects: [
+                    {
+                        objectType: "Employee",
+                        primaryKey: "e9",
+                        properties: { id: "e9" },
+                    },
+                ],
+            })
+        );
+        const links = createLiveOntologyLinks({
+            ir,
+            objects: {
+                Employee: memoryCollection([{ id: "e1" }], "id"),
+            },
+            backendLinks: {
+                list: backendList,
+                get: vi.fn(),
+            },
+        });
+
+        await expect(
+            links.list({ objectType: "Employee", primaryKey: "e1", link: "peers" })
+        ).resolves.toEqual({
+            objects: [{ objectType: "Employee", primaryKey: "e9", properties: { id: "e9" } }],
+        });
+        expect(backendList).toHaveBeenCalledWith(
+            expect.objectContaining({
+                objectType: "Employee",
+                primaryKey: "e1",
+                link: { sideName: "peers" },
+            })
+        );
+    });
+
+    it("errors when a non-FK link has no backend", async () => {
+        const links = createLiveOntologyLinks({
+            ir,
+            objects: {
+                Employee: memoryCollection([{ id: "e1" }], "id"),
+            },
+        });
+
+        await expect(
+            links.list({ objectType: "Employee", primaryKey: "e1", link: "peers" })
+        ).rejects.toBeInstanceOf(OntologyLinkError);
+    });
+});

--- a/packages/ontology/src/live/links/createLiveOntologyLinks.ts
+++ b/packages/ontology/src/live/links/createLiveOntologyLinks.ts
@@ -1,0 +1,363 @@
+import { eq, queryOnce, type Collection } from "@tanstack/db";
+import {
+    OntologyLinkError,
+    normalizeLinkRef,
+    resolveOntologyLink,
+    type ResolvedOntologyLink,
+} from "./resolveOntologyLink.js";
+import type { OntologyIR } from "../../ir/index.js";
+import type {
+    OntologyGetLinkOpts,
+    OntologyLinkPage,
+    OntologyLinkedObject,
+    OntologyLinksAdapter,
+    OntologyListLinksOpts,
+} from "../OntologyBackendAdapter.js";
+
+const LOCAL_FK_PAGE_TOKEN_PREFIX = "local-fk:";
+
+export interface LiveOntologyLinks {
+    get: (
+        opts: Omit<OntologyGetLinkOpts, "link"> & {
+            link: string | OntologyGetLinkOpts["link"];
+        }
+    ) => Promise<OntologyLinkedObject | undefined>;
+    list: (
+        opts: Omit<OntologyListLinksOpts, "link"> & {
+            link: string | OntologyListLinksOpts["link"];
+        }
+    ) => Promise<OntologyLinkPage>;
+}
+
+function toLinkedObject(
+    objectType: string,
+    primaryKeyProperty: string,
+    properties: Record<string, unknown>,
+    select?: string[]
+): OntologyLinkedObject | undefined {
+    const primaryKey = properties[primaryKeyProperty];
+    if (typeof primaryKey !== "string" && typeof primaryKey !== "number") {
+        return undefined;
+    }
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(properties)) {
+        if (key.startsWith("$") || (select && key !== primaryKeyProperty && !select.includes(key))) {
+            continue;
+        }
+        cleaned[key] = value;
+    }
+    return {
+        objectType,
+        primaryKey,
+        properties: cleaned,
+    };
+}
+
+async function queryObjects(
+    collection: Collection<Record<string, unknown>>,
+    primaryKeyProperty: string,
+    filter: { property: string; value: string | number },
+    opts: { limit?: number; offset?: number } = {}
+): Promise<Record<string, unknown>[]> {
+    return queryOnce((q) => {
+        let query = q
+            .from({ object: collection })
+            .where(({ object }) =>
+                eq(
+                    (object as Record<string, unknown>)[filter.property] as never,
+                    filter.value as never
+                )
+            )
+            .orderBy(
+                ({ object }) => (object as Record<string, unknown>)[primaryKeyProperty],
+                "asc"
+            );
+
+        if (opts.limit !== undefined) {
+            query = query.limit(opts.limit);
+        }
+        if (opts.offset !== undefined && opts.offset > 0) {
+            query = query.offset(opts.offset);
+        }
+
+        return query.select(({ object }) => object as Record<string, unknown>);
+    });
+}
+
+async function queryObject(
+    collection: Collection<Record<string, unknown>>,
+    primaryKeyProperty: string,
+    primaryKey: string | number
+): Promise<Record<string, unknown> | undefined> {
+    return (
+        await queryObjects(
+            collection,
+            primaryKeyProperty,
+            { property: primaryKeyProperty, value: primaryKey },
+            { limit: 1 }
+        )
+    )[0];
+}
+
+function parseLocalPageOffset(pageToken: string | undefined, pageSize: number | undefined): number {
+    if (pageToken === undefined) {
+        return 0;
+    }
+    if (pageSize === undefined) {
+        throw new OntologyLinkError("A local FK page token requires pageSize.");
+    }
+    if (!pageToken.startsWith(LOCAL_FK_PAGE_TOKEN_PREFIX)) {
+        throw new OntologyLinkError("Invalid local FK link page token.");
+    }
+    const offset = Number(pageToken.slice(LOCAL_FK_PAGE_TOKEN_PREFIX.length));
+    if (!Number.isSafeInteger(offset) || offset < 0) {
+        throw new OntologyLinkError("Invalid local FK link page token.");
+    }
+    return offset;
+}
+
+function normalizePageSize(pageSize: number | undefined): number | undefined {
+    if (pageSize === undefined) {
+        return undefined;
+    }
+    const normalized = Math.trunc(pageSize);
+    if (!Number.isSafeInteger(normalized) || normalized <= 0) {
+        throw new OntologyLinkError("Link pageSize must be a positive integer.");
+    }
+    return normalized;
+}
+
+function requirePrimaryKeyProperty(ir: OntologyIR, objectType: string): string {
+    const def = ir.objectTypes.find((candidate) => candidate.name === objectType);
+    if (!def) {
+        throw new OntologyLinkError(`Unknown object type "${objectType}".`);
+    }
+    return def.primaryKey;
+}
+
+async function listLocalFkLinks(opts: {
+    ir: OntologyIR;
+    objects: Record<string, Collection<Record<string, unknown>>>;
+    resolved: ResolvedOntologyLink;
+    objectType: string;
+    primaryKey: string | number;
+    pageSize?: number;
+    pageToken?: string;
+    select?: string[];
+}): Promise<OntologyLinkPage | undefined> {
+    const { resolved } = opts;
+    if (!resolved.foreignKey) {
+        return undefined;
+    }
+
+    const sourcePrimaryKey = requirePrimaryKeyProperty(opts.ir, opts.objectType);
+    const targetPrimaryKey = requirePrimaryKeyProperty(opts.ir, resolved.targetObjectType);
+    const sourceCollection = opts.objects[opts.objectType];
+    const targetCollection = opts.objects[resolved.targetObjectType];
+    if (!sourceCollection || !targetCollection) {
+        return undefined;
+    }
+    const pageSize = normalizePageSize(opts.pageSize);
+    const offset = parseLocalPageOffset(opts.pageToken, pageSize);
+
+    if (resolved.foreignKeyOnCurrentObject) {
+        if (offset > 0) {
+            return { objects: [] };
+        }
+        const source = await queryObject(sourceCollection, sourcePrimaryKey, opts.primaryKey);
+        if (!source) {
+            return { objects: [] };
+        }
+        const foreignKeyValue = source[resolved.foreignKey];
+        if (typeof foreignKeyValue !== "string" && typeof foreignKeyValue !== "number") {
+            return { objects: [] };
+        }
+        const target = await queryObject(targetCollection, targetPrimaryKey, foreignKeyValue);
+        const linked = target
+            ? toLinkedObject(resolved.targetObjectType, targetPrimaryKey, target, opts.select)
+            : undefined;
+        return { objects: linked ? [linked] : [] };
+    }
+
+    const rows = await queryObjects(
+        targetCollection,
+        targetPrimaryKey,
+        { property: resolved.foreignKey, value: opts.primaryKey },
+        {
+            limit: pageSize === undefined ? undefined : pageSize + 1,
+            offset,
+        }
+    );
+    const hasNextPage = pageSize !== undefined && rows.length > pageSize;
+    const pageRows = hasNextPage ? rows.slice(0, pageSize) : rows;
+    const objects = pageRows
+        .map((row) =>
+            toLinkedObject(resolved.targetObjectType, targetPrimaryKey, row, opts.select)
+        )
+        .filter((object): object is OntologyLinkedObject => object !== undefined);
+
+    return {
+        objects,
+        nextPageToken: hasNextPage
+            ? `${LOCAL_FK_PAGE_TOKEN_PREFIX}${offset + pageSize}`
+            : undefined,
+    };
+}
+
+async function getLocalFkLink(opts: {
+    ir: OntologyIR;
+    objects: Record<string, Collection<Record<string, unknown>>>;
+    resolved: ResolvedOntologyLink;
+    objectType: string;
+    primaryKey: string | number;
+    linkedPrimaryKey?: string | number;
+    select?: string[];
+}): Promise<{ supported: boolean; object?: OntologyLinkedObject }> {
+    const { resolved } = opts;
+    if (!resolved.foreignKey) {
+        return { supported: false };
+    }
+
+    const sourcePrimaryKey = requirePrimaryKeyProperty(opts.ir, opts.objectType);
+    const targetPrimaryKey = requirePrimaryKeyProperty(opts.ir, resolved.targetObjectType);
+    const sourceCollection = opts.objects[opts.objectType];
+    const targetCollection = opts.objects[resolved.targetObjectType];
+    if (!sourceCollection || !targetCollection) {
+        return { supported: false };
+    }
+
+    if (resolved.foreignKeyOnCurrentObject) {
+        const source = await queryObject(sourceCollection, sourcePrimaryKey, opts.primaryKey);
+        const foreignKeyValue = source?.[resolved.foreignKey];
+        if (typeof foreignKeyValue !== "string" && typeof foreignKeyValue !== "number") {
+            return { supported: true };
+        }
+        if (
+            opts.linkedPrimaryKey !== undefined &&
+            foreignKeyValue !== opts.linkedPrimaryKey
+        ) {
+            return { supported: true };
+        }
+        const target = await queryObject(targetCollection, targetPrimaryKey, foreignKeyValue);
+        return {
+            supported: true,
+            object: target
+                ? toLinkedObject(
+                      resolved.targetObjectType,
+                      targetPrimaryKey,
+                      target,
+                      opts.select
+                  )
+                : undefined,
+        };
+    }
+
+    if (opts.linkedPrimaryKey === undefined) {
+        if (resolved.cardinality === "many") {
+            throw new OntologyLinkError(
+                `Link "${opts.objectType}.${resolved.sideName}" is to-many; use links.list().`
+            );
+        }
+        const page = await listLocalFkLinks({
+            ...opts,
+            pageSize: 1,
+        });
+        return { supported: true, object: page?.objects[0] };
+    }
+
+    const target = await queryObject(
+        targetCollection,
+        targetPrimaryKey,
+        opts.linkedPrimaryKey
+    );
+    if (target?.[resolved.foreignKey] !== opts.primaryKey) {
+        return { supported: true };
+    }
+    return {
+        supported: true,
+        object: toLinkedObject(
+            resolved.targetObjectType,
+            targetPrimaryKey,
+            target,
+            opts.select
+        ),
+    };
+}
+
+export function createLiveOntologyLinks(opts: {
+    ir: OntologyIR;
+    objects: Record<string, Collection<Record<string, unknown>>>;
+    backendLinks?: OntologyLinksAdapter;
+}): LiveOntologyLinks {
+    const resolve = (objectType: string, link: string | OntologyGetLinkOpts["link"]) =>
+        resolveOntologyLink(opts.ir, objectType, normalizeLinkRef(link));
+
+    return {
+        get: async ({ objectType, primaryKey, link, linkedPrimaryKey, select }) => {
+            const resolved = resolve(objectType, link);
+
+            if (resolved.foreignKey) {
+                const local = await getLocalFkLink({
+                    ir: opts.ir,
+                    objects: opts.objects,
+                    resolved,
+                    objectType,
+                    primaryKey,
+                    linkedPrimaryKey,
+                    select,
+                });
+                if (local.supported) {
+                    return local.object;
+                }
+            }
+
+            if (!opts.backendLinks) {
+                throw new OntologyLinkError(
+                    `Link "${objectType}.${resolved.sideName}" cannot be traversed locally and no backend links adapter is configured.`
+                );
+            }
+
+            return opts.backendLinks.get({
+                objectType,
+                primaryKey,
+                link: { sideName: resolved.sideName },
+                linkedPrimaryKey,
+                select,
+            });
+        },
+        list: async ({ objectType, primaryKey, link, pageSize, pageToken, select }) => {
+            const resolved = resolve(objectType, link);
+
+            if (resolved.foreignKey) {
+                const page = await listLocalFkLinks({
+                    ir: opts.ir,
+                    objects: opts.objects,
+                    resolved,
+                    objectType,
+                    primaryKey,
+                    pageSize,
+                    pageToken,
+                    select,
+                });
+                if (page) {
+                    return page;
+                }
+            }
+
+            if (!opts.backendLinks) {
+                throw new OntologyLinkError(
+                    `Link "${objectType}.${resolved.sideName}" cannot be traversed locally and no backend links adapter is configured.`
+                );
+            }
+
+            return opts.backendLinks.list({
+                objectType,
+                primaryKey,
+                link: { sideName: resolved.sideName },
+                pageSize,
+                pageToken,
+                select,
+            });
+        },
+    };
+}

--- a/packages/ontology/src/live/links/resolveOntologyLink.test.ts
+++ b/packages/ontology/src/live/links/resolveOntologyLink.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import blog from "../../examples/blog.js";
+import { o } from "../../ir/index.js";
+import { OntologyLinkError, resolveOntologyLink } from "./resolveOntologyLink.js";
+import type { OntologyIR } from "../../ir/index.js";
+
+/** Matches Foundry meta conversion: FK owner is `source`, side names are outbound from each endpoint. */
+const ir: OntologyIR = {
+    types: [],
+    objectTypes: [
+        {
+            name: "Employee",
+            displayName: "Employee",
+            pluralDisplayName: "Employees",
+            primaryKey: "id",
+            properties: [
+                { name: "id", displayName: "Id", type: o.string({}) },
+                { name: "departmentId", displayName: "Department", type: o.string({}) },
+            ],
+        },
+        {
+            name: "Department",
+            displayName: "Department",
+            pluralDisplayName: "Departments",
+            primaryKey: "id",
+            properties: [{ name: "id", displayName: "Id", type: o.string({}) }],
+        },
+    ],
+    linkTypes: [
+        {
+            id: "ri.link.employee-department",
+            source: {
+                objectType: "Employee",
+                name: "employees",
+                displayName: "Employees",
+                cardinality: "many",
+            },
+            target: {
+                objectType: "Department",
+                name: "department",
+                displayName: "Department",
+                cardinality: "one",
+            },
+            foreignKey: "departmentId",
+            cardinality: "many",
+        },
+        {
+            id: "ri.link.non-fk",
+            source: {
+                objectType: "Employee",
+                name: "peerOf",
+                displayName: "Peer of",
+                cardinality: "many",
+            },
+            target: {
+                objectType: "Employee",
+                name: "peers",
+                displayName: "Peers",
+                cardinality: "many",
+            },
+            cardinality: "many",
+        },
+    ],
+    actionTypes: [],
+    queryFunctionTypes: [],
+};
+
+describe("resolveOntologyLink", () => {
+    it("follows the canonical opposite-side name convention used by existing IR", () => {
+        expect(resolveOntologyLink(blog, "Post", { sideName: "author" })).toMatchObject({
+            targetObjectType: "Author",
+            sideName: "author",
+            inverseSideName: "posts",
+            foreignKey: "authorId",
+            cardinality: "one",
+        });
+        expect(resolveOntologyLink(blog, "Author", { sideName: "posts" })).toMatchObject({
+            targetObjectType: "Post",
+            sideName: "posts",
+            inverseSideName: "author",
+            foreignKey: "authorId",
+            cardinality: "many",
+        });
+        expect(resolveOntologyLink(blog, "Comment", { sideName: "author" })).toMatchObject({
+            targetObjectType: "Author",
+            sideName: "author",
+            inverseSideName: "comment",
+            foreignKey: "authorId",
+            cardinality: "one",
+        });
+    });
+
+    it("resolves forward and reverse FK sides", () => {
+        expect(resolveOntologyLink(ir, "Employee", { sideName: "department" })).toMatchObject({
+            targetObjectType: "Department",
+            sideName: "department",
+            foreignKey: "departmentId",
+            foreignKeyOnCurrentObject: true,
+            cardinality: "one",
+        });
+
+        expect(resolveOntologyLink(ir, "Department", { sideName: "employees" })).toMatchObject({
+            targetObjectType: "Employee",
+            sideName: "employees",
+            foreignKey: "departmentId",
+            foreignKeyOnCurrentObject: false,
+            cardinality: "many",
+        });
+    });
+
+    it("resolves by stable link id", () => {
+        expect(resolveOntologyLink(ir, "Employee", { id: "ri.link.employee-department" })).toMatchObject({
+            sideName: "department",
+            targetObjectType: "Department",
+        });
+    });
+
+    it("keeps non-FK links resolvable", () => {
+        expect(resolveOntologyLink(ir, "Employee", { sideName: "peers" })).toMatchObject({
+            foreignKey: undefined,
+            sideName: "peers",
+            targetObjectType: "Employee",
+        });
+    });
+
+    it("throws for unknown links", () => {
+        expect(() => resolveOntologyLink(ir, "Employee", { sideName: "missing" })).toThrow(
+            OntologyLinkError
+        );
+    });
+});

--- a/packages/ontology/src/live/links/resolveOntologyLink.ts
+++ b/packages/ontology/src/live/links/resolveOntologyLink.ts
@@ -1,0 +1,133 @@
+import type { LinkTypeDef, OntologyIR } from "../../ir/index.js";
+
+export class OntologyLinkError extends Error {
+    constructor(message: string, opts?: { cause?: unknown }) {
+        super(message, opts?.cause !== undefined ? { cause: opts.cause } : undefined);
+        this.name = "OntologyLinkError";
+    }
+}
+
+export type ResolvedOntologyLink = {
+    link: LinkTypeDef;
+    /** Object type at the far end of this traversal. */
+    targetObjectType: string;
+    /** Side API name used when talking to a backend from the current object. */
+    sideName: string;
+    /** Inverse side API name. */
+    inverseSideName: string;
+    foreignKey?: string;
+    /** True when the foreign key property lives on the current (source) object. */
+    foreignKeyOnCurrentObject: boolean;
+    cardinality: "one" | "many";
+};
+
+function objectTypeOwnsForeignKey(
+    ir: OntologyIR,
+    link: LinkTypeDef,
+    objectType: string
+): boolean {
+    if (!link.foreignKey) {
+        return false;
+    }
+    const objectTypeDefinition = ir.objectTypes.find((candidate) => candidate.name === objectType);
+    if (!objectTypeDefinition?.properties.some((property) => property.name === link.foreignKey)) {
+        return false;
+    }
+    // Join keys commonly share a name with the referenced type's primary key.
+    // The FK owner is the endpoint where that property is not the primary key.
+    return (
+        link.source.objectType === link.target.objectType ||
+        objectTypeDefinition.primaryKey !== link.foreignKey
+    );
+}
+
+/**
+ * Finds a link by stable id, or by the outbound side API name from `sourceObjectType`.
+ *
+ * A side describes the role of objects on that side. From the source object, callers use
+ * `target.name`; from the target object, callers use `source.name`.
+ */
+export function findLinkType(
+    ir: OntologyIR,
+    sourceObjectType: string,
+    linkRef: { sideName: string } | { id: string }
+): LinkTypeDef | undefined {
+    if ("id" in linkRef) {
+        return ir.linkTypes.find((candidate) => candidate.id === linkRef.id);
+    }
+    return ir.linkTypes.find(
+        (candidate) =>
+            (candidate.source.objectType === sourceObjectType &&
+                candidate.target.name === linkRef.sideName) ||
+            (candidate.target.objectType === sourceObjectType &&
+                candidate.source.name === linkRef.sideName)
+    );
+}
+
+export function resolveOntologyLink(
+    ir: OntologyIR,
+    sourceObjectType: string,
+    linkRef: { sideName: string } | { id: string }
+): ResolvedOntologyLink {
+    const link = findLinkType(ir, sourceObjectType, linkRef);
+    if (!link) {
+        const label = "id" in linkRef ? `id=${linkRef.id}` : linkRef.sideName;
+        throw new OntologyLinkError(`Link "${sourceObjectType}.${label}" was not found in the ontology IR.`);
+    }
+
+    const fromSourceEndpoint =
+        "id" in linkRef
+            ? link.source.objectType === sourceObjectType
+            : link.source.objectType === sourceObjectType && link.target.name === linkRef.sideName;
+
+    if (
+        "id" in linkRef &&
+        link.source.objectType !== sourceObjectType &&
+        link.target.objectType !== sourceObjectType
+    ) {
+        throw new OntologyLinkError(
+            `Link id "${linkRef.id}" does not connect object type "${sourceObjectType}".`
+        );
+    }
+
+    if (fromSourceEndpoint) {
+        return {
+            link,
+            targetObjectType: link.target.objectType,
+            sideName: link.target.name,
+            inverseSideName: link.source.name,
+            foreignKey: link.foreignKey,
+            foreignKeyOnCurrentObject:
+                link.source.objectType === link.target.objectType ||
+                objectTypeOwnsForeignKey(ir, link, link.source.objectType),
+            cardinality:
+                link.target.cardinality ??
+                (link.foreignKey
+                    ? "one"
+                    : link.cardinality === "one"
+                      ? "many"
+                      : "one"),
+        };
+    }
+
+    return {
+        link,
+        targetObjectType: link.source.objectType,
+        sideName: link.source.name,
+        inverseSideName: link.target.name,
+        foreignKey: link.foreignKey,
+        foreignKeyOnCurrentObject:
+            link.source.objectType !== link.target.objectType &&
+            objectTypeOwnsForeignKey(ir, link, link.target.objectType),
+        cardinality: link.source.cardinality ?? link.cardinality,
+    };
+}
+
+export function normalizeLinkRef(
+    link: string | { sideName: string } | { id: string }
+): { sideName: string } | { id: string } {
+    if (typeof link === "string") {
+        return { sideName: link };
+    }
+    return link;
+}

--- a/packages/ontology/src/meta/createStaticMetaOntologyBackend.ts
+++ b/packages/ontology/src/meta/createStaticMetaOntologyBackend.ts
@@ -1,0 +1,91 @@
+import type { OntologyIR } from "../ir/index.js";
+import type {
+    OntologyBackendAdapter,
+    OntologyBackendAdapterProvider,
+    OntologyCollectionOptions,
+} from "../live/OntologyBackendAdapter.js";
+import type { SyncConfig } from "@tanstack/db";
+
+export interface CreateStaticMetaOntologyBackendAdapterOptions {
+    ir: OntologyIR;
+    name?: string;
+}
+
+function createStaticCollectionOptions(
+    rows: Array<Record<string, unknown>>
+): OntologyCollectionOptions {
+    const sync: SyncConfig<Record<string, unknown>, string | number> = {
+        sync: ({ begin, write, commit, markReady }) => {
+            begin();
+            for (const row of rows) {
+                write({ type: "insert", value: row });
+            }
+            commit();
+            markReady();
+            return {
+                loadSubset: () => true,
+                cleanup: () => {},
+            };
+        },
+    };
+
+    return {
+        syncMode: "eager",
+        startSync: true,
+        sync,
+    };
+}
+
+/**
+ * Creates a read-only meta ontology backend from an existing {@link OntologyIR}.
+ *
+ * The resulting adapter exposes the same meta collections as the Foundry meta backend
+ * (`ObjectType`, `LinkType`, `ValueType`, `ActionType`, `QueryFunctionType`) so local and
+ * Foundry deployments can share `createMetaLiveOntology` + `pull()` code paths.
+ */
+export function createStaticMetaOntologyBackendAdapter(
+    opts: CreateStaticMetaOntologyBackendAdapterOptions
+): OntologyBackendAdapter {
+    const collections: Record<string, OntologyCollectionOptions> = {
+        ObjectType: createStaticCollectionOptions(opts.ir.objectTypes as Array<Record<string, unknown>>),
+        LinkType: createStaticCollectionOptions(opts.ir.linkTypes as Array<Record<string, unknown>>),
+        ValueType: createStaticCollectionOptions(opts.ir.types as Array<Record<string, unknown>>),
+        ActionType: createStaticCollectionOptions(opts.ir.actionTypes as Array<Record<string, unknown>>),
+        QueryFunctionType: createStaticCollectionOptions(
+            opts.ir.queryFunctionTypes as Array<Record<string, unknown>>
+        ),
+    };
+
+    return {
+        name: opts.name ?? "static-metadata",
+        getCollectionOptions: (objectType) => {
+            const options = collections[objectType];
+            if (!options) {
+                throw new Error(`Unsupported static metadata object type "${objectType}".`);
+            }
+            return options;
+        },
+        applyAction: () => {
+            return Promise.reject(new Error("Static meta ontology backends are read-only."));
+        },
+        runQueryFunction: () => {
+            return Promise.reject(new Error("Static meta ontology backends are read-only."));
+        },
+    };
+}
+
+export type CreateStaticMetaOntologyBackendOptions = {
+    ir: OntologyIR;
+    name?: string;
+};
+
+/**
+ * Provider form of {@link createStaticMetaOntologyBackendAdapter} for use with
+ * `createMetaLiveOntology({ backend })`. The provider IR (meta schema) is ignored;
+ * collections are populated from the supplied data IR.
+ */
+export function createStaticMetaOntologyBackend(
+    opts: CreateStaticMetaOntologyBackendOptions
+): OntologyBackendAdapterProvider {
+    return () => createStaticMetaOntologyBackendAdapter(opts);
+}

--- a/packages/ontology/src/meta/generated/types.ts
+++ b/packages/ontology/src/meta/generated/types.ts
@@ -169,6 +169,8 @@ export type LinkTypeSideDef = {
     objectType: string;
     name: string;
     displayName: string;
+    /** How many objects on this side participate in the link. */
+    cardinality?: "one" | "many";
 };
 
 /** The cardinality of a link from the source's perspective. */
@@ -282,11 +284,15 @@ export type ValueType = {
 export type ObjectType = {
     /** The object type's programmatic name. */
     name: string;
+    /** Optional backend-neutral identifier for the object type. Foundry adapters map the object-type RID into this field. */
+    id?: string;
     /** Human-readable name. */
     displayName: string;
     pluralDisplayName: string;
     /** The name of the property that serves as primary key. */
     primaryKey: string;
+    /** Optional property used as the human-readable title/label for instances of this object type. */
+    titleProperty?: string;
     /** The object type's propertieo. */
     properties: Array<PropertyDef>;
     /** Optional description. */
@@ -299,9 +305,9 @@ export type LinkType = {
     id: string;
     source: LinkTypeSideDef;
     target: LinkTypeSideDef;
-    /** The foreign key on the source. */
-    foreignKey: string;
-    /** How many sources are linked to the target. */
+    /** Optional foreign key on the source. When omitted, traversal requires a backend link capability. */
+    foreignKey?: string;
+    /** How many sources are linked to the target. Prefer source.cardinality when present. */
     cardinality: "one" | "many";
 };
 
@@ -309,6 +315,8 @@ export type LinkType = {
 export type ActionType = {
     /** The object type's programmatic name. */
     name: string;
+    /** Optional backend-neutral identifier for the action type. Foundry adapters map the action-type RID into this field. */
+    id?: string;
     /** Human-readable name. */
     displayName: string;
     /** The action type's parametero. */

--- a/packages/ontology/src/meta/pull.test.ts
+++ b/packages/ontology/src/meta/pull.test.ts
@@ -1,0 +1,268 @@
+import { eq, queryOnce } from "@tanstack/db";
+import { describe, expect, it } from "vitest";
+import blog from "../examples/blog.js";
+import { o } from "../ir/index.js";
+import { createStaticMetaOntologyBackend } from "./createStaticMetaOntologyBackend.js";
+import { createMetaLiveOntology } from "./generated/live.js";
+import { pull } from "./pull.js";
+import type { OntologyIR } from "../ir/index.js";
+
+const fixtureIr: OntologyIR = {
+    types: [
+        {
+            name: "Address",
+            type: o.struct({
+                fields: [{ name: "city", displayName: "City", type: o.string({}) }],
+            }),
+        },
+        {
+            name: "UnusedType",
+            type: o.string({}),
+        },
+    ],
+    objectTypes: [
+        {
+            name: "Author",
+            id: "ri.ontology.main.object-type.author",
+            displayName: "Author",
+            pluralDisplayName: "Authors",
+            primaryKey: "authorId",
+            titleProperty: "name",
+            properties: [
+                { name: "authorId", displayName: "Author ID", type: o.string({}) },
+                { name: "name", displayName: "Name", type: o.string({}) },
+                {
+                    name: "address",
+                    displayName: "Address",
+                    type: o.optional({ type: o.ref({ name: "Address" }) }),
+                },
+            ],
+        },
+        {
+            name: "Post",
+            id: "ri.ontology.main.object-type.post",
+            displayName: "Post",
+            pluralDisplayName: "Posts",
+            primaryKey: "postId",
+            titleProperty: "title",
+            properties: [
+                { name: "postId", displayName: "Post ID", type: o.string({}) },
+                { name: "title", displayName: "Title", type: o.string({}) },
+                { name: "authorId", displayName: "Author ID", type: o.string({}) },
+            ],
+        },
+        {
+            name: "Orphan",
+            displayName: "Orphan",
+            pluralDisplayName: "Orphans",
+            primaryKey: "id",
+            properties: [{ name: "id", displayName: "ID", type: o.string({}) }],
+        },
+    ],
+    linkTypes: [
+        {
+            id: "Post:author",
+            source: { objectType: "Post", name: "posts", displayName: "Posts", cardinality: "many" },
+            target: {
+                objectType: "Author",
+                name: "author",
+                displayName: "Author",
+                cardinality: "one",
+            },
+            foreignKey: "authorId",
+            cardinality: "many",
+        },
+        {
+            id: "Orphan:self",
+            source: { objectType: "Orphan", name: "orphans", displayName: "Orphans" },
+            target: { objectType: "Orphan", name: "self", displayName: "Self" },
+            foreignKey: "id",
+            cardinality: "one",
+        },
+    ],
+    actionTypes: [
+        {
+            name: "createPost",
+            id: "ri.actions.main.action-type.create-post",
+            displayName: "Create Post",
+            parameters: [
+                {
+                    name: "title",
+                    displayName: "Title",
+                    type: o.string({}),
+                },
+                {
+                    name: "author",
+                    displayName: "Author",
+                    type: o.objectReference({ objectType: "Author" }),
+                },
+            ],
+            logic: [
+                {
+                    kind: "createObject",
+                    value: {
+                        objectType: "Post",
+                        values: [
+                            {
+                                property: ["title"],
+                                value: {
+                                    kind: "valueReference",
+                                    value: { path: ["title"] },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            name: "unusedAction",
+            displayName: "Unused",
+            parameters: [],
+            logic: [],
+        },
+    ],
+    queryFunctionTypes: [
+        {
+            name: "searchPosts",
+            displayName: "Search Posts",
+            parameters: [{ name: "query", displayName: "Query", type: o.string({}) }],
+            returnType: o.list({ elementType: o.ref({ name: "Address" }) }),
+        },
+        {
+            name: "unusedQuery",
+            displayName: "Unused Query",
+            parameters: [],
+            returnType: o.string({}),
+        },
+    ],
+};
+
+describe("createStaticMetaOntologyBackend + pull", () => {
+    it("exposes meta collections that preserve ids and title properties", async () => {
+        const meta = await createMetaLiveOntology({
+            backend: createStaticMetaOntologyBackend({ ir: fixtureIr }),
+            persistObjects: false,
+            writes: { defaultMode: "direct" },
+        });
+
+        try {
+            const objectType = await queryOnce((q) =>
+                q
+                    .from({ ObjectType: meta.objects.ObjectType })
+                    .where(({ ObjectType }) => eq(ObjectType.id, "ri.ontology.main.object-type.author"))
+                    .findOne()
+            );
+            expect(objectType).toMatchObject({
+                name: "Author",
+                id: "ri.ontology.main.object-type.author",
+                titleProperty: "name",
+            });
+
+            const actionType = await queryOnce((q) =>
+                q
+                    .from({ ActionType: meta.objects.ActionType })
+                    .where(({ ActionType }) =>
+                        eq(ActionType.id, "ri.actions.main.action-type.create-post")
+                    )
+                    .findOne()
+            );
+            expect(actionType).toMatchObject({
+                name: "createPost",
+                id: "ri.actions.main.action-type.create-post",
+            });
+        } finally {
+            await meta.cleanup();
+        }
+    });
+
+    it("pulls a scoped OntologyIR including transitive value types and links", async () => {
+        const meta = await createMetaLiveOntology({
+            backend: createStaticMetaOntologyBackend({ ir: fixtureIr }),
+            persistObjects: false,
+            writes: { defaultMode: "direct" },
+        });
+
+        try {
+            const pulled = await pull(meta, {
+                objectTypeNames: ["Author", "Post"],
+                actionTypeNames: ["createPost"],
+                queryFunctionTypeNames: ["searchPosts"],
+            });
+
+            expect(pulled.objectTypes.map((objectType) => objectType.name).sort()).toEqual([
+                "Author",
+                "Post",
+            ]);
+            expect(pulled.objectTypes.find((objectType) => objectType.name === "Author")).toMatchObject({
+                id: "ri.ontology.main.object-type.author",
+                titleProperty: "name",
+            });
+            expect(pulled.linkTypes.map((linkType) => linkType.id)).toEqual(["Post:author"]);
+            expect(pulled.actionTypes).toHaveLength(1);
+            expect(pulled.actionTypes[0]).toMatchObject({
+                name: "createPost",
+                id: "ri.actions.main.action-type.create-post",
+            });
+            expect(pulled.queryFunctionTypes.map((query) => query.name)).toEqual(["searchPosts"]);
+            expect(pulled.types.map((type) => type.name).sort()).toEqual(["Address"]);
+        } finally {
+            await meta.cleanup();
+        }
+    });
+
+    it("supports empty selections and rejects writes", async () => {
+        const meta = await createMetaLiveOntology({
+            backend: createStaticMetaOntologyBackend({ ir: fixtureIr }),
+            persistObjects: false,
+            writes: { defaultMode: "direct" },
+        });
+
+        try {
+            await expect(
+                pull(meta, {
+                    objectTypeNames: [],
+                    actionTypeNames: [],
+                    queryFunctionTypeNames: [],
+                })
+            ).resolves.toEqual({
+                types: [],
+                objectTypes: [],
+                linkTypes: [],
+                actionTypes: [],
+                queryFunctionTypes: [],
+            });
+
+            expect(meta.actions).toBeDefined();
+            const backend = createStaticMetaOntologyBackend({ ir: fixtureIr });
+            const adapter = await backend(fixtureIr, {});
+            await expect(adapter.applyAction("noop", {}, { objects: {} })).rejects.toThrow(/read-only/);
+            await expect(adapter.runQueryFunction("noop", {}, { objects: {} })).rejects.toThrow(
+                /read-only/
+            );
+        } finally {
+            await meta.cleanup();
+        }
+    });
+
+    it("works with the blog example ontology", async () => {
+        const meta = await createMetaLiveOntology({
+            backend: createStaticMetaOntologyBackend({ ir: blog }),
+            persistObjects: false,
+            writes: { defaultMode: "direct" },
+        });
+
+        try {
+            const pulled = await pull(meta, {
+                objectTypeNames: ["Author", "Post", "Comment"],
+                actionTypeNames: ["createPost"],
+                queryFunctionTypeNames: [],
+            });
+            expect(pulled.objectTypes).toHaveLength(3);
+            expect(pulled.linkTypes.length).toBeGreaterThan(0);
+            expect(pulled.types.map((type) => type.name)).toContain("Address");
+        } finally {
+            await meta.cleanup();
+        }
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1074,55 +1074,6 @@ importers:
         specifier: ^3.1.1
         version: 3.2.4(@types/debug@4.1.12)(@types/node@26.1.2)(@vitest/browser@3.2.4)(jiti@2.7.0)(jsdom@27.2.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
 
-  packages/runtime-services:
-    dependencies:
-      idb:
-        specifier: ^8.0.3
-        version: 8.0.3
-      temporal-polyfill:
-        specifier: ^0.3.0
-        version: 0.3.0
-    devDependencies:
-      '@bobbyfidz/universal-build-config':
-        specifier: ^0.1.1
-        version: 0.1.1(eslint@9.28.0(jiti@2.6.1))(typescript@5.8.3)
-      '@tanstack/browser-db-sqlite-persistence':
-        specifier: ^0.2.6
-        version: 0.2.6(@journeyapps/wa-sqlite@1.7.2)(typescript@5.8.3)
-      '@tanstack/db':
-        specifier: ^0.6.14
-        version: 0.6.14(typescript@5.8.3)
-      '@tanstack/db-sqlite-persistence-core':
-        specifier: ^0.2.6
-        version: 0.2.6(typescript@5.8.3)
-      '@tanstack/expo-db-sqlite-persistence':
-        specifier: ^0.2.6
-        version: 0.2.6(expo-sqlite@55.0.15(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(typescript@5.8.3)
-      '@vitest/browser':
-        specifier: 3.2.4
-        version: 3.2.4(playwright@1.61.1)(vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)
-      eslint:
-        specifier: ^9.25.0
-        version: 9.28.0(jiti@2.6.1)
-      expo-file-system:
-        specifier: ^55.0.19
-        version: 55.0.19(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))
-      expo-sqlite:
-        specifier: ^55.0.15
-        version: 55.0.15(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      fake-indexeddb:
-        specifier: ^6.2.5
-        version: 6.2.5
-      playwright:
-        specifier: ^1.61.1
-        version: 1.61.1
-      typescript:
-        specifier: ~5.8.3
-        version: 5.8.3
-      vitest:
-        specifier: ^3.1.1
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
-
   packages/sqlite-ontology:
     dependencies:
       '@party-stack/ontology':
@@ -1235,10 +1186,6 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-annotate-as-pure@7.29.7':
     resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
     engines: {node: '>=6.9.0'}
@@ -1251,20 +1198,8 @@ packages:
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-create-class-features-plugin@7.29.3':
-    resolution: {integrity: sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-create-class-features-plugin@7.29.7':
     resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-create-regexp-features-plugin@7.28.5':
-    resolution: {integrity: sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1286,10 +1221,6 @@ packages:
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-member-expression-to-functions@7.28.5':
-    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.29.7':
@@ -1316,10 +1247,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@7.27.1':
-    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-optimise-call-expression@7.29.7':
     resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
     engines: {node: '>=6.9.0'}
@@ -1332,20 +1259,8 @@ packages:
     resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-remap-async-to-generator@7.27.1':
-    resolution: {integrity: sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-remap-async-to-generator@7.29.7':
     resolution: {integrity: sha512-16AMiW26DbXWBbr3B8wNozKM0ydMLB892vaOaJW/fPJdnT8vJk5sdkQcU/isqUxyCE0cEoa8wZOcbgDuC4b6Og==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
-  '@babel/helper-replace-supers@7.28.6':
-    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -1355,10 +1270,6 @@ packages:
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
@@ -1388,10 +1299,6 @@ packages:
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-wrap-function@7.28.6':
-    resolution: {integrity: sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-wrap-function@7.29.7':
     resolution: {integrity: sha512-iES0Skag9ERIF68aXadpO6dbXa03mNWK3sEqJaMnLNs/eC3l0lkImdfoy6Y09/SfkpawdAB4RjQ7PVA7TcVGdw==}
     engines: {node: '>=6.9.0'}
@@ -1418,32 +1325,14 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/plugin-proposal-decorators@7.29.0':
-    resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-proposal-decorators@7.29.7':
     resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-proposal-export-default-from@7.27.1':
-    resolution: {integrity: sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-proposal-export-default-from@7.29.7':
     resolution: {integrity: sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-decorators@7.28.6':
-    resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1459,20 +1348,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-export-default-from@7.28.6':
-    resolution: {integrity: sha512-Svlx1fjJFnNz0LZeUaybRukSxZI3KkpApUmIRzEdXC5k8ErTOz0OD0kNrICi5Vc3GlpP5ZCeRyRO+mfWTSz+iQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-syntax-export-default-from@7.29.7':
     resolution: {integrity: sha512-foag0BB37ROhdeIX9O8G0jX7hw0UekJc04cHMrYLOnrErsnBKqJGHJ8eDRpoCFZBvEPPygmmtw4qyU97qa4oOw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-flow@7.28.6':
-    resolution: {integrity: sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1517,20 +1394,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-arrow-functions@7.27.1':
-    resolution: {integrity: sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-arrow-functions@7.29.7':
     resolution: {integrity: sha512-N7zArUXWzAMzm+/N0uPBeVB3Fam5lMxtUwMmDK5f/IBBS7a7p1qeUoxd/6CckXoxUdgsntq1Dh8xNW06maZbDQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-async-generator-functions@7.29.0':
-    resolution: {integrity: sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1541,20 +1406,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-async-to-generator@7.28.6':
-    resolution: {integrity: sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-async-to-generator@7.29.7':
     resolution: {integrity: sha512-pcUb2SS+RMo9TWVBwKGI5ShtoG7R+zBsFmCKDa6fe8c+hPr3XJlZgoE5j6i8W7gDjhyvy+85vmYexanvXh3d1w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-block-scoping@7.28.6':
-    resolution: {integrity: sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1565,23 +1418,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-class-properties@7.28.6':
-    resolution: {integrity: sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-class-properties@7.29.7':
     resolution: {integrity: sha512-GtcpjFvanPfzNQi3eTitsCqtRRmmqzpy/A+yhTR1HaZo1Ly3EA8ZXxlPyHdR8/IuRMYc3E4wdGBewB2QKQjAaA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-class-static-block@7.28.6':
-    resolution: {integrity: sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.12.0
 
   '@babel/plugin-transform-class-static-block@7.29.7':
     resolution: {integrity: sha512-kibJgmEdX2iMwsHY2tSZNDgj8PwIlCQz7FK9KuGKO8zsuoUwSEhoNnNVp/emKWrbY4HeO6kkXfdMqRKKKXBm2A==}
@@ -1589,20 +1430,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.12.0
 
-  '@babel/plugin-transform-classes@7.28.6':
-    resolution: {integrity: sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-classes@7.29.7':
     resolution: {integrity: sha512-qV0OGGBVacduzQHE649JyCneOFI/maT+YKsO+K4Yi3xv2wTPNjM/W2o2gdzMwEAZz7fXNTHAe0NcSg30bIN69g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-computed-properties@7.28.6':
-    resolution: {integrity: sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1613,20 +1442,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-destructuring@7.28.5':
-    resolution: {integrity: sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-destructuring@7.29.7':
     resolution: {integrity: sha512-iPX8aD6H9zV5s7ZsqTdNocPN/MGQ5sSMnElKrktxjJRMnB2jN/1p2+R7GkfD6CAYoVFqy5A4XnSIUeGgJzIWpg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-export-namespace-from@7.27.1':
-    resolution: {integrity: sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1637,20 +1454,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-flow-strip-types@7.27.1':
-    resolution: {integrity: sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-flow-strip-types@7.29.7':
     resolution: {integrity: sha512-wRHeUjUjCZnMHmiO5bRgjFLcoEh7JyTdByOW11ahhwNa4V0bmeGEaIvt51yq0zQp2yWIpqfxXXPyUP6GFJZHOQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-for-of@7.27.1':
-    resolution: {integrity: sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1661,20 +1466,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-function-name@7.27.1':
-    resolution: {integrity: sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-function-name@7.29.7':
     resolution: {integrity: sha512-otRWaHXE6fbAGkePvaj/kvs3HsqXfPhlnzwSOlnFgbqCPMd975dW+4wZ00WFBt+/YlBGcJwNrARQTOJOb4ZrIg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-literals@7.27.1':
-    resolution: {integrity: sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1685,20 +1478,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6':
-    resolution: {integrity: sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-logical-assignment-operators@7.29.7':
     resolution: {integrity: sha512-A0H91hh6W8MFRkp5TqJmMr39jzGD1A1E1Ysiv2O06Sfbhkapm+XyIzxWCEh5kqwOZ1/8QZ0dY3SeQ7XBqfJd5Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1709,32 +1490,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0':
-    resolution: {integrity: sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7':
     resolution: {integrity: sha512-vuFoLwr4qnv2xbZ16SQd6uPcH5FNrLHhk/Jzo++0XJFcaDsr4gjJVg6j398oMHiC+83k/GiBzviwF5KBJkPUtQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6':
-    resolution: {integrity: sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7':
     resolution: {integrity: sha512-idmp1dFaekP9GbcMvG24Kvw2BfhFZjHnNJCkV4WuIY4PskJzwI3f1N5OdgYke38T7rftO6ERulFRn2cFeZwRkg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-numeric-separator@7.28.6':
-    resolution: {integrity: sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1745,20 +1508,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-object-rest-spread@7.28.6':
-    resolution: {integrity: sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-object-rest-spread@7.29.7':
     resolution: {integrity: sha512-Ld98jn4c0smUywL57m7SgsHq3OpThOa6LqZJif3G6jYOovPleoFhVrBJ1WegRApSFB2wu4+RelAj9AC9G08Z4A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-optional-catch-binding@7.28.6':
-    resolution: {integrity: sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1769,20 +1520,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-optional-chaining@7.28.6':
-    resolution: {integrity: sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-optional-chaining@7.29.7':
     resolution: {integrity: sha512-6GM1dhvK3gNODkXcEcMCOLEDCLSoZ/sBbro2Ax8HURyasQ4NshagQixkRFdh5niI6E4gmA/jYI/4aT7rRos3ZQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-parameters@7.27.7':
-    resolution: {integrity: sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1793,20 +1532,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-private-methods@7.28.6':
-    resolution: {integrity: sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-private-methods@7.29.7':
     resolution: {integrity: sha512-/6Rz4DK1ETDEM/bWHsPHcaEe7ZaT1EqSXjtSP/L0DijOYuaUhiRiOKcwpZ8P7zR4xXEHc2ITdiCgBm9Tpyv9ug==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-private-property-in-object@7.28.6':
-    resolution: {integrity: sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1817,20 +1544,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-display-name@7.28.0':
-    resolution: {integrity: sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-display-name@7.29.7':
     resolution: {integrity: sha512-+1wdDMGNb4UPeY3Q4L5yLiYe6TXPXubs4NjrgRFw13hPRLJfEMw2Q5OXkee6/IfdqePIeW4Jjwe3aBh7SdKz4Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-development@7.27.1':
-    resolution: {integrity: sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1865,20 +1580,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-react-jsx@7.28.6':
-    resolution: {integrity: sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-react-jsx@7.29.7':
     resolution: {integrity: sha512-WsZulLVBUHXVj2cUcPVx6UE21TpalB6bHbSFErKT0Ib++ax24jjXe73FqlWvdylFOjiuPHYi6VCcgRad1ItN+A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-pure-annotations@7.27.1':
-    resolution: {integrity: sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1889,20 +1592,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.29.0':
-    resolution: {integrity: sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-regenerator@7.29.7':
     resolution: {integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-runtime@7.29.0':
-    resolution: {integrity: sha512-jlaRT5dJtMaMCV6fAuLbsQMSwz/QkvaHOHOSXRitGGwSpR1blCY4KUKoyP2tYO8vJcqYe8cEj96cqSztv3uF9w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1913,20 +1604,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1':
-    resolution: {integrity: sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-shorthand-properties@7.29.7':
     resolution: {integrity: sha512-I+WYbGBAiCn7nA6xBrlgPH+MB7HWb4u8pv5S0Pv7OtwNvIFvCCb24YlttKEeUFVurfBCEaOTnuhlqsb7f0Z5Dg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-spread@7.28.6':
-    resolution: {integrity: sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1937,20 +1616,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-sticky-regex@7.27.1':
-    resolution: {integrity: sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-sticky-regex@7.29.7':
     resolution: {integrity: sha512-BCHzNYJGe9l7EpwwDBN/ztlL2NYFFq8hp9ddjtUEM9f2O7S7kKV/lL6Fwo7IF7NSkYhPK2vO+86nIGltA90MsA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-typescript@7.28.6':
-    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -1961,32 +1628,14 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-unicode-regex@7.27.1':
-    resolution: {integrity: sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-unicode-regex@7.29.7':
     resolution: {integrity: sha512-7D/x/23/d/3VqZ0QA+LGbZMlGwZjztBygSWWWsfTPoQ1oQ6Q1P6Mr3d0kk42XabyUVw+fha3LqdRsFqeKqvCyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/preset-react@7.28.5':
-    resolution: {integrity: sha512-Z3J8vhRq7CeLjdC58jLv4lnZ5RKFUJWqH5emvxmv9Hv3BD1T9R/Im713R4MTKwvFaV74ejZ3sM01LyEKk4ugNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/preset-react@7.29.7':
     resolution: {integrity: sha512-C+PV1TFUPTmBQGoPBL8j2QmLpZ117YTCwxIZeJOM96GbYMFSc7/pOXU5lVykwnZxyTqQxRsvoRk6f2FktZgGHA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/preset-typescript@7.28.5':
-    resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
@@ -2473,17 +2122,8 @@ packages:
   '@expo/config-plugins@55.0.11':
     resolution: {integrity: sha512-85ZSmIK8rMfvYbG/2IHtwnykVdb6LI0ZavduM3ZwUMThyyVegYjVsO5Zek2ec8xzPhCmYX0ar5onnFEcwUDUlw==}
 
-  '@expo/config-plugins@55.0.8':
-    resolution: {integrity: sha512-8WfWTRntTCcowfOS+tHdB0z98gKetTwktg4G5TWkCkXVa8Jt1NUnvzaaU4UHk2vbR2U4N84RyZJFizSwfF6C9g==}
-
-  '@expo/config-types@55.0.5':
-    resolution: {integrity: sha512-sCmSUZG4mZ/ySXvfyyBdhjivz8Q539X1NondwDdYG7s3SBsk+wsgPJzYsqgAG/P9+l0xWjUD2F+kQ1cAJ6NNLg==}
-
   '@expo/config-types@55.0.6':
     resolution: {integrity: sha512-S+GJKYoIjnWlert/9vXuTohaTsMbyOLSVxdIgPgoq3P4N1p4CWrfyZLnz6qRug8wYSO5fcYcS9mFleyEP8wRLg==}
-
-  '@expo/config@55.0.16':
-    resolution: {integrity: sha512-H5dpQv5TfyZDNheZAWO3SmP10diGWZwN5QOUsArkDJih0QKNtahQBOmrV2xbhgln/nrUGoy41U/ZIY/MEx63Ug==}
 
   '@expo/config@55.0.19':
     resolution: {integrity: sha512-MahrCR6LsElK/1r/C/zfEZ5Pdgmo88Gtd4CCnASv/rC2pUIB+ENt2oKRHAPIWi7McTeoqDPb9KwCkQBpNMOjrg==}
@@ -2509,10 +2149,6 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@expo/env@2.1.2':
-    resolution: {integrity: sha512-RJtGFfj/ygO/6zcVbV3cckHf4THcEkv5IZft1GjCB3dfT6axvzvIwXE9EiQqQYmGHcQ+ZrvC8xZcIhiHba0pYg==}
-    engines: {node: '>=20.12.0'}
-
   '@expo/env@2.1.3':
     resolution: {integrity: sha512-Rhu/lJ1kOhqzJvLwW0iB4WKUzB1nFa8WBwXFL44qkSTNwibjrbI8lA46Ix6W2MMTdlUqL1m85Gdyx0T7nGpREg==}
     engines: {node: '>=20.12.0'}
@@ -2525,14 +2161,8 @@ packages:
     resolution: {integrity: sha512-BH8sicYOqZ1iBMwCVEGIz6uTTfylosjc49FoMmCYIzKOiYdiVehsfoYBwyfxwWIiya1VMhm1gv0cgOP8fxHpDw==}
     hasBin: true
 
-  '@expo/image-utils@0.8.14':
-    resolution: {integrity: sha512-5Sn+jG4Cw+shC2wDMXoqSAJnvERbiwzHn05FpWtD5IBflfTIs5gUmjzwiGVyjOdlMSQhgRrw/AymPbmO9h9mpQ==}
-
   '@expo/image-utils@0.8.15':
     resolution: {integrity: sha512-3f5CgKJnJ8m4mp8VTcAFQqLrxof99RDr77Aa+7hgzDPg3ZotjLnofl77hf+COQRYi/kuqRYdYFgPIqOIOIdWJA==}
-
-  '@expo/json-file@10.0.14':
-    resolution: {integrity: sha512-yWwBFywFv+SxkJp/pIzzA416JVYflNUh7pqQzgaA6nXDqRyK7KfrqVzk8PdUfDnqbBcaZZxpzNssfQZzp5KHrA==}
 
   '@expo/json-file@10.0.16':
     resolution: {integrity: sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==}
@@ -2565,43 +2195,20 @@ packages:
   '@expo/metro@55.1.1':
     resolution: {integrity: sha512-/wfXo5hTuAVpVLG/4hzlmD9NBGJkzkmBEMm/4VICajYRbj7y8OmqqPWbbymzHiBiHB6tI9BnsyXpQM6zVZEECg==}
 
-  '@expo/osascript@2.4.3':
-    resolution: {integrity: sha512-wbuj3EebM7W9hN/Wp4xTzKd6rQ2zKJzAxkFxkOOwyysLp0HOAgQ4/5RINyoS241pZUX2rUHq7mAJ7pcCQ8U0Ow==}
-    engines: {node: '>=12'}
-
   '@expo/osascript@2.7.1':
     resolution: {integrity: sha512-Zn03EX6In7ts2lPUW2ESUSkEhEWQN1qqsiXjadtZMJOuZRkMiAg1ZQHuvz9DjByDWNJ2pBwAGyrts9lj9k389g==}
     engines: {node: '>=12'}
 
-  '@expo/package-manager@1.10.5':
-    resolution: {integrity: sha512-nCP9Mebfl3jvOr0/P6VAuyah6PAtun+aihIL2zAtuE8uSe94JWkVZ7051i0MUVO+y3gFpBqnr8IIH5ch+VJjHA==}
-
   '@expo/package-manager@1.13.1':
     resolution: {integrity: sha512-y/K+CaYYpZpNGZhSX4HyLT/vyIunFjNfyoxNysPBCefeLKI/VCx6f9LNPzrxayr3rCYO5bl9O8H+HRQK265Nkg==}
 
-  '@expo/plist@0.5.3':
-    resolution: {integrity: sha512-jz5oPcPDd3fygwVxwSwmO6wodTwm0Qa14NUyPy0ka7H8sFmCtNZUI2+DzVe/EXjOhq1FbEjrwl89gdlWYOnVjQ==}
-
   '@expo/plist@0.5.4':
     resolution: {integrity: sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg==}
-
-  '@expo/prebuild-config@55.0.17':
-    resolution: {integrity: sha512-Mcs+dg4Ripu0yCtzf66KZr18PehI1O8HxzJw+G5SUF8VWX+ic99aci1PltvmydWepLwTQL6ykmpXicAUA31IqA==}
-    peerDependencies:
-      expo: '*'
 
   '@expo/prebuild-config@55.0.20':
     resolution: {integrity: sha512-Cy9xnwK0f3aG0TbKkBFuVQCtd6rj22muYfj7o1iCAE0NOUy5ks1k2vcmlKD1g48wzcWw0hFySiwtaGsB9qeVRQ==}
     peerDependencies:
       expo: '*'
-
-  '@expo/require-utils@55.0.5':
-    resolution: {integrity: sha512-U4K/CQ2VpXuwfNGsN+daKmYOt15hCP8v/pXaYH6eut7kdYZo6SfJ1yr67BIcJ+1Gzzs+QzTxswAZChKpXmceyw==}
-    peerDependencies:
-      typescript: ^5.0.0 || ^5.0.0-0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   '@expo/require-utils@55.0.6':
     resolution: {integrity: sha512-IqsRGPdGbF0lAIrg3XQ+GzcITYcsskvIRmFAjw2kBnr8RgSrRhFAJY1bKksukEUsuZy0knhTCVIIUce7hocqeA==}
@@ -2609,28 +2216,6 @@ packages:
       typescript: ^5.0.0 || ^5.0.0-0
     peerDependenciesMeta:
       typescript:
-        optional: true
-
-  '@expo/router-server@55.0.16':
-    resolution: {integrity: sha512-LvAdrm039nQBG+95+ff5Rc4CsBuoc/giDhjQrgxB9lKJqC/ZTq1xbwfEZFNq6yokX6fOCs/vlxdhmSkOjMIrvg==}
-    peerDependencies:
-      '@expo/metro-runtime': ^55.0.11
-      expo: '*'
-      expo-constants: ^55.0.16
-      expo-font: ^55.0.7
-      expo-router: '*'
-      expo-server: ^55.0.9
-      react: '*'
-      react-dom: '*'
-      react-server-dom-webpack: ~19.0.1 || ~19.1.2 || ~19.2.1
-    peerDependenciesMeta:
-      '@expo/metro-runtime':
-        optional: true
-      expo-router:
-        optional: true
-      react-dom:
-        optional: true
-      react-server-dom-webpack:
         optional: true
 
   '@expo/router-server@55.0.18':
@@ -2655,18 +2240,11 @@ packages:
       react-server-dom-webpack:
         optional: true
 
-  '@expo/schema-utils@55.0.4':
-    resolution: {integrity: sha512-65IdeeE8dAZR3n3J5Eq7LYiQ8BFGeEYCWPBCzycvafL7PkskbCyIclTQarRwf/HXFoRvezKCjaLwy/8v9Prk6g==}
-
   '@expo/schema-utils@55.0.5':
     resolution: {integrity: sha512-wdV4SzWJ/l+6y/r9vDaqPqXGyfxUD1igbX8rRbRBfkVXenAUY2qenq6HF4S0iJ0pjpVDNTANn5aQY7VV55hhsA==}
 
   '@expo/sdk-runtime-versions@1.0.0':
     resolution: {integrity: sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==}
-
-  '@expo/spawn-async@1.7.2':
-    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
-    engines: {node: '>=12'}
 
   '@expo/spawn-async@1.8.0':
     resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
@@ -2684,10 +2262,6 @@ packages:
 
   '@expo/ws-tunnel@1.0.6':
     resolution: {integrity: sha512-nDRbLmSrJar7abvUjp3smDwH8HcbZcoOEa5jVPUv9/9CajgmWw20JNRwTuBRzWIWIkEJDkz20GoNA+tSwUqk0Q==}
-
-  '@expo/xcpretty@4.4.3':
-    resolution: {integrity: sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==}
-    hasBin: true
 
   '@expo/xcpretty@4.4.4':
     resolution: {integrity: sha512-4aQzz9vgxcNXFfo/iyNgDDYfsU5XGKKxWxZopw0cVotHiW+U8IJbIxMaxsINs6bHhtkG3StKNPcOrn3eBuxKPw==}
@@ -2777,9 +2351,6 @@ packages:
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
-  '@journeyapps/wa-sqlite@1.7.2':
-    resolution: {integrity: sha512-EVRMzqHtHgJBFcTGOgQ5/YlxrYFSXLFFztC5yo6+jQx2mqFR+a1kkLV4IirquiBzIonjmYXfBtvZ26fmI8r9Nw==}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -3055,30 +2626,14 @@ packages:
     resolution: {integrity: sha512-iRfhxsOePloy12TUzpL9dCwnxLi3eurg8+JurSozAmWh4HtmKu0IJHNjbEKk9htI5n4RlFom8LQ9vVcvgWOTbw==}
     engines: {node: '>= 20.19.4'}
 
-  '@react-native/babel-plugin-codegen@0.83.6':
-    resolution: {integrity: sha512-qfRXsHGeucT5c6mK+8Q7v4Ly3zmygfVmFlEtkiq7q07W1OTreld6nib4rJ/DBEeNiKBoBTuHjWliYGNuDjLFQA==}
-    engines: {node: '>= 20.19.4'}
-
   '@react-native/babel-preset@0.83.10':
     resolution: {integrity: sha512-wTZWvs5cUQqr2qBAoJNKUy6IBH7wqPAJdxTC834S/7vBqtXypYHxDAFzYXkIh8pRTC86IBYxyc2IrBYHnB8O2g==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
 
-  '@react-native/babel-preset@0.83.6':
-    resolution: {integrity: sha512-4/fXFDUvGOObETZq4+SUFkafld6OGgQWut5cQiqVghlhCB5z/p2lVhPgEUr/aTxTzeS3AmN+ztC+GpYPQ7tsTw==}
-    engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
-
   '@react-native/codegen@0.83.10':
     resolution: {integrity: sha512-rTcuuwRDPLrBmhXc9vAr2gispQFCEqd2WVPh2+N5eV80p8tf9mHy7CoFnmPy8A8csK6HGlANaD9SMPvccQjh4g==}
-    engines: {node: '>= 20.19.4'}
-    peerDependencies:
-      '@babel/core': '*'
-
-  '@react-native/codegen@0.83.6':
-    resolution: {integrity: sha512-doB/Pq6Cf6IjF3wlQXTIiZOnsX9X8mEEk+CdGfyuCwZjWrf7IB8KaZEXXckJmfUcIwvJ9u/a72ZoTTCIoxAc9A==}
     engines: {node: '>= 20.19.4'}
     peerDependencies:
       '@babel/core': '*'
@@ -3135,9 +2690,6 @@ packages:
 
   '@react-native/normalize-colors@0.83.10':
     resolution: {integrity: sha512-dWgqcxaBy27oLx9tndcTF0917vbLOOstyNjYD58J6Z7YxkEZSaKG6+A+3I1KV6O1Xg2D69QThp4t6ezoC3NiGA==}
-
-  '@react-native/normalize-colors@0.83.6':
-    resolution: {integrity: sha512-bTM24b5v4qN3h52oflnv+OujFORn/kVi06WaWhnQQw14/ycilPqIsqsa+DpIBqdBrXxvLa9fXtCRrQtGATZCEw==}
 
   '@react-native/normalize-colors@0.85.3':
     resolution: {integrity: sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw==}
@@ -3485,12 +3037,6 @@ packages:
     resolution: {integrity: sha512-4+9w8ZHOiGnpcGI6z1TVVfWaX/koK7fKeSYF3qlYg2xpBtbteP2ddBxiarL+HVgfSJGeK5RIxRQmKm4rTJJAwA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
-
-  '@tanstack/browser-db-sqlite-persistence@0.2.6':
-    resolution: {integrity: sha512-l78NOmRmdoFc+QoZmkvS1D1RkWaayUFMX+230Z20CP00tZBDgGWvSL6ubVLwf1IpcaY4AFsVuZmcfVDteE4UxQ==}
-    peerDependencies:
-      '@journeyapps/wa-sqlite': ^1.4.1
-      typescript: '>=4.7'
 
   '@tanstack/db-ivm@0.1.18':
     resolution: {integrity: sha512-+pZJiRKdoKRM5Epq9T7otD9ZJl82pRFauo7LKuJGrarjVKQ7r+QQlPe3kGdN9LEKSnuNGIWjX9OOY4M8kH4eLw==}
@@ -3845,9 +3391,6 @@ packages:
 
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
-
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@types/node@26.1.2':
     resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
@@ -4229,21 +3772,6 @@ packages:
 
   babel-plugin-transform-flow-enums@0.0.2:
     resolution: {integrity: sha512-g4aaCrDDOsWjbm0PUUeVnkcVd6AKJsVc/MbnPhEotEpkeJQP6b8nzewohQi7+QS8UyPehOhGWn0nOwjvWpmMvQ==}
-
-  babel-preset-expo@55.0.21:
-    resolution: {integrity: sha512-anXoUZBcxydLdVs2L+r3bWKGUvZv2FtgOl8xRJ12i/YfKICBpwTGZWSTiEYTqBByZ6GkA3mE9+3TW97X2ocFTQ==}
-    peerDependencies:
-      '@babel/runtime': ^7.20.0
-      expo: '*'
-      expo-widgets: ^55.0.17
-      react-refresh: '>=0.14.0 <1.0.0'
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-      expo:
-        optional: true
-      expo-widgets:
-        optional: true
 
   babel-preset-expo@55.0.24:
     resolution: {integrity: sha512-dzjg70cq3Ls5msL79GSktjqtbjzXh/r5errxz8aD97S180pkXrMga22ozrcNhHddMBtZGDKN2jBK1FS1RLkfBQ==}
@@ -4790,9 +4318,6 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
-  dnssd-advertise@1.1.4:
-    resolution: {integrity: sha512-AmGyK9WpNf06WeP5TjHZq/wNzP76OuEeaiTlKr9E/EEelYLczywUKoqRz+DPRq/ErssjT4lU+/W7wzJW+7K/ZA==}
-
   dnssd-advertise@1.1.6:
     resolution: {integrity: sha512-Ndrrf6BMPalkQPd/zubL+4YghH2J9NspapQ09uDXwYbvOPkP0oaqf5CkcwJ0b50kS2O3ul6yVu+jz+RY62Cejg==}
 
@@ -5095,24 +4620,11 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
-  expo-asset@55.0.17:
-    resolution: {integrity: sha512-pK9HHJuFqjE8kDUcbMFsZj3Cz8WdXpvZHZmYl7ouFQp59P83BvHln6VnqPDGlO+/4929G0Lm8ZUzbONuNRhi9w==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
-      react-native: '*'
-
   expo-asset@55.0.18:
     resolution: {integrity: sha512-dbNMcBE0AaFbdxjBSRgDLdtOi8PHt9CQOg+J3EdeXNPKZCDO88kvaHcXaYUMmkbN2KJYQlfu1GxfUVAIoi7iVQ==}
     peerDependencies:
       expo: '*'
       react: '*'
-      react-native: '*'
-
-  expo-constants@55.0.16:
-    resolution: {integrity: sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ==}
-    peerDependencies:
-      expo: '*'
       react-native: '*'
 
   expo-constants@55.0.17:
@@ -5131,13 +4643,6 @@ packages:
     resolution: {integrity: sha512-7/HJdvaaf3kP5T3atd+6Q0/QexrGio4Fs2GVtp7G8d/xQCSu01yeGReu7tGQo9VAM67Snq+ujGlL8q2wbMXLkQ==}
     peerDependencies:
       expo: '*'
-      react-native: '*'
-
-  expo-font@55.0.7:
-    resolution: {integrity: sha512-oH39Xb+3i6Y69b7YRP+P+5WLx7621t+ep/RAgLwJJYpTjs7CnSohUG+873rEtqsTAuQGi63ms7x9ZeHj1E9LYw==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
       react-native: '*'
 
   expo-font@55.0.8:
@@ -5169,10 +4674,6 @@ packages:
 
   expo-server@55.0.11:
     resolution: {integrity: sha512-AxRdHqcv0H1g4s923vu+5n1Nrhne23bjXbP+Vl7+Lwfpe7MG9PuU1IS95IJK6a+7BVV1mRN6QlZvs8Yv7EEXNQ==}
-    engines: {node: '>=20.16.0'}
-
-  expo-server@55.0.9:
-    resolution: {integrity: sha512-N5Ipn1NwqaJzEm+G97o0Jbe4g/th3R/16N1DabnYryXKCiZwDkK13/w3VfGkQN9LOOaBP+JIRxGf4M8lQKPzyA==}
     engines: {node: '>=20.16.0'}
 
   expo-sqlite@55.0.15:
@@ -6067,12 +5568,6 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  lightningcss-android-arm64@1.32.0:
-    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [android]
-
   lightningcss-android-arm64@1.33.0:
     resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
     engines: {node: '>= 12.0.0'}
@@ -6081,12 +5576,6 @@ packages:
 
   lightningcss-darwin-arm64@1.30.2:
     resolution: {integrity: sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  lightningcss-darwin-arm64@1.32.0:
-    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -6103,12 +5592,6 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  lightningcss-darwin-x64@1.32.0:
-    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
   lightningcss-darwin-x64@1.33.0:
     resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
     engines: {node: '>= 12.0.0'}
@@ -6117,12 +5600,6 @@ packages:
 
   lightningcss-freebsd-x64@1.30.2:
     resolution: {integrity: sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  lightningcss-freebsd-x64@1.32.0:
-    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -6139,12 +5616,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm]
-    os: [linux]
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
     resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
     engines: {node: '>= 12.0.0'}
@@ -6153,12 +5624,6 @@ packages:
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  lightningcss-linux-arm64-gnu@1.32.0:
-    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -6175,12 +5640,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
   lightningcss-linux-arm64-musl@1.33.0:
     resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
     engines: {node: '>= 12.0.0'}
@@ -6189,12 +5648,6 @@ packages:
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  lightningcss-linux-x64-gnu@1.32.0:
-    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -6211,12 +5664,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  lightningcss-linux-x64-musl@1.32.0:
-    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [linux]
-
   lightningcss-linux-x64-musl@1.33.0:
     resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
     engines: {node: '>= 12.0.0'}
@@ -6225,12 +5672,6 @@ packages:
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  lightningcss-win32-arm64-msvc@1.32.0:
-    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -6247,12 +5688,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  lightningcss-win32-x64-msvc@1.32.0:
-    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
-    engines: {node: '>= 12.0.0'}
-    cpu: [x64]
-    os: [win32]
-
   lightningcss-win32-x64-msvc@1.33.0:
     resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
     engines: {node: '>= 12.0.0'}
@@ -6261,10 +5696,6 @@ packages:
 
   lightningcss@1.30.2:
     resolution: {integrity: sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==}
-    engines: {node: '>= 12.0.0'}
-
-  lightningcss@1.32.0:
-    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lightningcss@1.33.0:
@@ -7905,11 +7336,6 @@ packages:
     resolution: {integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==}
     engines: {node: '>=8'}
 
-  terser@5.46.2:
-    resolution: {integrity: sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   terser@5.49.0:
     resolution: {integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==}
     engines: {node: '>=10'}
@@ -8134,9 +7560,6 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -8366,9 +7789,6 @@ packages:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
 
-  whatwg-url-minimum@0.1.1:
-    resolution: {integrity: sha512-u2FNVjFVFZhdjb502KzXy1gKn1mEisQRJssmSJT8CPhZdZa0AP6VCbWlXERKyGu0l09t0k50FiDiralpGhBxgA==}
-
   whatwg-url-minimum@0.1.2:
     resolution: {integrity: sha512-XPEm0XFQWNVG292lII1PrRRJl3sItrs7CettZ4ncYxuDVpLyy+NwlGyut2hXI0JswcJUxeCH+CyOJK0ZzAXD6A==}
 
@@ -8426,18 +7846,6 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
-
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@7.5.13:
     resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
@@ -8680,10 +8088,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/helper-annotate-as-pure@7.27.3':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -8704,19 +8108,6 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -8730,30 +8121,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-create-regexp-features-plugin@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      regexpu-core: 6.4.0
-      semver: 6.3.1
-
   '@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
-
-  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
-      lodash.debounce: 4.0.8
-      resolve: 1.22.12
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
@@ -8769,13 +8142,6 @@ snapshots:
   '@babel/helper-globals@7.28.0': {}
 
   '@babel/helper-globals@7.29.7': {}
-
-  '@babel/helper-member-expression-to-functions@7.28.5':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
@@ -8816,10 +8182,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@7.27.1':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@babel/helper-optimise-call-expression@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
@@ -8827,15 +8189,6 @@ snapshots:
   '@babel/helper-plugin-utils@7.28.6': {}
 
   '@babel/helper-plugin-utils@7.29.7': {}
-
-  '@babel/helper-remap-async-to-generator@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-wrap-function': 7.28.6
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -8846,28 +8199,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-member-expression-to-functions': 7.28.5
-      '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.29.7
       '@babel/helper-optimise-call-expression': 7.29.7
       '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8889,14 +8226,6 @@ snapshots:
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helper-wrap-function@7.28.6':
-    dependencies:
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/helper-wrap-function@7.29.7':
     dependencies:
@@ -8931,15 +8260,6 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -8949,50 +8269,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-export-default-from@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-proposal-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-export-default-from@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-export-default-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-flow@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-flow@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9009,20 +8304,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
     dependencies:
@@ -9039,24 +8324,10 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9064,15 +8335,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-remap-async-to-generator': 7.29.7(@babel/core@7.29.7)
       '@babel/traverse': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9085,23 +8347,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-block-scoping@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9111,31 +8360,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-classes@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-globals': 7.28.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9151,25 +8380,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-computed-properties@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/template': 7.28.6
-
   '@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/template': 7.29.7
-
-  '@babel/plugin-transform-destructuring@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9179,21 +8394,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
 
   '@babel/plugin-transform-flow-strip-types@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9201,28 +8405,11 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
 
-  '@babel/plugin-transform-for-of@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-function-name@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9235,33 +8422,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-literals@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9271,48 +8440,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9325,23 +8467,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9351,38 +8480,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-parameters@7.27.7(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -9395,22 +8502,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9439,17 +8534,6 @@ snapshots:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -9461,39 +8545,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.0)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9507,23 +8568,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-shorthand-properties@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-spread@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9533,26 +8581,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-sticky-regex@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9565,29 +8597,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
-      '@babel/helper-plugin-utils': 7.28.6
-
   '@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-create-regexp-features-plugin': 7.29.7(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-react@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -9598,17 +8612,6 @@ snapshots:
       '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-jsx-development': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-react-pure-annotations': 7.29.7(@babel/core@7.29.7)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10226,81 +9229,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@55.0.29(bfd3siqyehv3mcoji6txwhfafu)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 55.0.16(typescript@5.8.3)
-      '@expo/config-plugins': 55.0.8
-      '@expo/devcert': 1.2.1
-      '@expo/env': 2.1.2
-      '@expo/image-utils': 0.8.14(typescript@5.8.3)
-      '@expo/json-file': 10.0.14
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.20(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)
-      '@expo/osascript': 2.4.3
-      '@expo/package-manager': 1.10.5
-      '@expo/plist': 0.5.3
-      '@expo/prebuild-config': 55.0.17(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)
-      '@expo/require-utils': 55.0.5(typescript@5.8.3)
-      '@expo/router-server': 55.0.16(expo-constants@55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)))(expo-font@55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo-server@55.0.9)(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@expo/schema-utils': 55.0.4
-      '@expo/spawn-async': 1.7.2
-      '@expo/ws-tunnel': 1.0.6
-      '@expo/xcpretty': 4.4.3
-      '@react-native/dev-middleware': 0.83.6
-      accepts: 1.3.8
-      arg: 5.0.2
-      better-opn: 3.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1
-      connect: 3.7.0
-      debug: 4.4.3(supports-color@8.1.1)
-      dnssd-advertise: 1.1.4
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      expo-server: 55.0.9
-      fetch-nodeshim: 0.4.10
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      multitars: 1.0.0
-      node-forge: 1.4.0
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.4
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      send: 0.19.2
-      slugify: 1.6.9
-      source-map-support: 0.5.21
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.20.0
-      zod: 3.25.76
-    optionalDependencies:
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@expo/code-signing-certificates@0.0.6':
     dependencies:
       node-forge: 1.4.0
@@ -10323,43 +9251,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/config-plugins@55.0.8':
-    dependencies:
-      '@expo/config-types': 55.0.5
-      '@expo/json-file': 10.0.14
-      '@expo/plist': 0.5.3
-      '@expo/sdk-runtime-versions': 1.0.0
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-      glob: 13.0.6
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      slugify: 1.6.9
-      xcode: 3.0.1
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/config-types@55.0.5': {}
-
   '@expo/config-types@55.0.6': {}
-
-  '@expo/config@55.0.16(typescript@5.8.3)':
-    dependencies:
-      '@expo/config-plugins': 55.0.8
-      '@expo/config-types': 55.0.5
-      '@expo/json-file': 10.0.14
-      '@expo/require-utils': 55.0.5(typescript@5.8.3)
-      deepmerge: 4.3.1
-      getenv: 2.0.0
-      glob: 13.0.6
-      resolve-workspace-root: 2.0.1
-      semver: 7.7.4
-      slugify: 1.6.9
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   '@expo/config@55.0.19(typescript@5.8.3)':
     dependencies:
@@ -10384,13 +9276,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/devtools@55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      chalk: 4.1.2
-    optionalDependencies:
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-
   '@expo/devtools@55.0.3(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
     dependencies:
       chalk: 4.1.2
@@ -10398,25 +9283,11 @@ snapshots:
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
 
-  '@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-
   '@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
     dependencies:
       expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
-
-  '@expo/env@2.1.2':
-    dependencies:
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@expo/env@2.1.3':
     dependencies:
@@ -10450,19 +9321,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/image-utils@0.8.14(typescript@5.8.3)':
-    dependencies:
-      '@expo/require-utils': 55.0.5(typescript@5.8.3)
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      getenv: 2.0.0
-      jimp-compact: 0.16.1
-      parse-png: 2.1.0
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@expo/image-utils@0.8.15(typescript@5.8.3)':
     dependencies:
       '@expo/require-utils': 55.0.6(typescript@5.8.3)
@@ -10475,11 +9333,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  '@expo/json-file@10.0.14':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      json5: 2.2.3
 
   '@expo/json-file@10.0.16':
     dependencies:
@@ -10504,15 +9357,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      anser: 1.4.10
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-      stacktrace-parser: 0.1.11
-
   '@expo/log-box@55.0.12(@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@expo/dom-webview': 55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
@@ -10521,35 +9365,6 @@ snapshots:
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
       stacktrace-parser: 0.1.11
-
-  '@expo/metro-config@55.0.20(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/generator': 7.29.1
-      '@expo/config': 55.0.16(typescript@5.8.3)
-      '@expo/env': 2.1.2
-      '@expo/json-file': 10.0.14
-      '@expo/metro': 55.1.1
-      '@expo/spawn-async': 1.7.2
-      browserslist: 4.28.2
-      chalk: 4.1.2
-      debug: 4.4.3(supports-color@8.1.1)
-      getenv: 2.0.0
-      glob: 13.0.6
-      hermes-parser: 0.32.1
-      jsc-safe-url: 0.2.4
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.4.49
-      resolve-from: 5.0.0
-    optionalDependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   '@expo/metro-config@55.0.20(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
@@ -10601,22 +9416,9 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@expo/osascript@2.4.3':
-    dependencies:
-      '@expo/spawn-async': 1.7.2
-
   '@expo/osascript@2.7.1':
     dependencies:
       '@expo/spawn-async': 1.8.0
-
-  '@expo/package-manager@1.10.5':
-    dependencies:
-      '@expo/json-file': 10.0.14
-      '@expo/spawn-async': 1.7.2
-      chalk: 4.1.2
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      resolve-workspace-root: 2.0.1
 
   '@expo/package-manager@1.13.1':
     dependencies:
@@ -10627,34 +9429,11 @@ snapshots:
       ora: 3.4.0
       resolve-workspace-root: 2.0.1
 
-  '@expo/plist@0.5.3':
-    dependencies:
-      '@xmldom/xmldom': 0.8.13
-      base64-js: 1.5.1
-      xmlbuilder: 15.1.1
-
   '@expo/plist@0.5.4':
     dependencies:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  '@expo/prebuild-config@55.0.17(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@expo/config': 55.0.16(typescript@5.8.3)
-      '@expo/config-plugins': 55.0.8
-      '@expo/config-types': 55.0.5
-      '@expo/image-utils': 0.8.14(typescript@5.8.3)
-      '@expo/json-file': 10.0.14
-      '@react-native/normalize-colors': 0.83.6
-      debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      resolve-from: 5.0.0
-      semver: 7.7.4
-      xml2js: 0.6.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   '@expo/prebuild-config@55.0.20(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)':
     dependencies:
@@ -10673,16 +9452,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@expo/require-utils@55.0.5(typescript@5.8.3)':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-    optionalDependencies:
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@expo/require-utils@55.0.6(typescript@5.8.3)':
     dependencies:
       '@babel/code-frame': 7.29.7
@@ -10690,19 +9459,6 @@ snapshots:
       '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7)
     optionalDependencies:
       typescript: 5.8.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/router-server@55.0.16(expo-constants@55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)))(expo-font@55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo-server@55.0.9)(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      expo-constants: 55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))
-      expo-font: 55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      expo-server: 55.0.9
-      react: 19.2.0
-    optionalDependencies:
-      react-dom: 19.2.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -10719,27 +9475,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/schema-utils@55.0.4': {}
-
   '@expo/schema-utils@55.0.5': {}
 
   '@expo/sdk-runtime-versions@1.0.0': {}
-
-  '@expo/spawn-async@1.7.2':
-    dependencies:
-      cross-spawn: 7.0.6
 
   '@expo/spawn-async@1.8.0':
     dependencies:
       cross-spawn: 7.0.6
 
   '@expo/sudo-prompt@9.3.2': {}
-
-  '@expo/vector-icons@15.1.1(expo-font@55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      expo-font: 55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
 
   '@expo/vector-icons@15.1.1(expo-font@55.0.8(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -10748,12 +9492,6 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
 
   '@expo/ws-tunnel@1.0.6': {}
-
-  '@expo/xcpretty@4.4.3':
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      chalk: 4.1.2
-      js-yaml: 4.1.1
 
   '@expo/xcpretty@4.4.4':
     dependencies:
@@ -10836,8 +9574,6 @@ snapshots:
       '@types/node': 24.10.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
-
-  '@journeyapps/wa-sqlite@1.7.2': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -11259,14 +9995,6 @@ snapshots:
       - '@babel/core'
       - supports-color
 
-  '@react-native/babel-plugin-codegen@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/traverse': 7.29.0
-      '@react-native/codegen': 0.83.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
   '@react-native/babel-preset@0.83.10(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11317,56 +10045,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/babel-preset@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/template': 7.28.6
-      '@react-native/babel-plugin-codegen': 0.83.6(@babel/core@7.29.0)
-      babel-plugin-syntax-hermes-parser: 0.32.0
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      react-refresh: 0.14.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@react-native/codegen@0.83.10(@babel/core@7.29.7)':
     dependencies:
       '@babel/core': 7.29.7
@@ -11376,26 +10054,6 @@ snapshots:
       invariant: 2.2.4
       nullthrows: 1.1.1
       yargs: 17.7.3
-
-  '@react-native/codegen@0.83.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
-      glob: 7.2.3
-      hermes-parser: 0.32.0
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      yargs: 17.7.2
-
-  '@react-native/codegen@0.85.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.3
-      hermes-parser: 0.33.3
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      tinyglobby: 0.2.16
-      yargs: 17.7.2
 
   '@react-native/codegen@0.85.3(@babel/core@7.29.7)':
     dependencies:
@@ -11482,18 +10140,7 @@ snapshots:
 
   '@react-native/normalize-colors@0.83.10': {}
 
-  '@react-native/normalize-colors@0.83.6': {}
-
   '@react-native/normalize-colors@0.85.3': {}
-
-  '@react-native/virtualized-lists@0.85.3(@types/react@19.2.6)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
-    dependencies:
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-    optionalDependencies:
-      '@types/react': 19.2.6
 
   '@react-native/virtualized-lists@0.85.3(@types/react@19.2.6)(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -11758,12 +10405,6 @@ snapshots:
       tailwindcss: 4.1.17
       vite: 7.2.4(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
 
-  '@tanstack/browser-db-sqlite-persistence@0.2.6(@journeyapps/wa-sqlite@1.7.2)(typescript@5.8.3)':
-    dependencies:
-      '@journeyapps/wa-sqlite': 1.7.2
-      '@tanstack/db-sqlite-persistence-core': 0.2.6(typescript@5.8.3)
-      typescript: 5.8.3
-
   '@tanstack/db-ivm@0.1.18(typescript@5.8.3)':
     dependencies:
       fractional-indexing: 3.2.0
@@ -11857,12 +10498,6 @@ snapshots:
       - bufferutil
       - csstype
       - utf-8-validate
-
-  '@tanstack/expo-db-sqlite-persistence@0.2.6(expo-sqlite@55.0.15(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(typescript@5.8.3)':
-    dependencies:
-      '@tanstack/db-sqlite-persistence-core': 0.2.6(typescript@5.8.3)
-      expo-sqlite: 55.0.15(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      typescript: 5.8.3
 
   '@tanstack/expo-db-sqlite-persistence@0.2.6(expo-sqlite@55.0.15(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(typescript@5.8.3)':
     dependencies:
@@ -12211,11 +10846,6 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
-    optional: true
-
   '@types/node@26.1.2':
     dependencies:
       undici-types: 8.3.0
@@ -12412,25 +11042,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.61.1)(vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)':
-    dependencies:
-      '@testing-library/dom': 10.4.1
-      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0))
-      '@vitest/utils': 3.2.4
-      magic-string: 0.30.21
-      sirv: 3.0.2
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
-      ws: 8.20.0
-    optionalDependencies:
-      playwright: 1.61.1
-    transitivePeerDependencies:
-      - bufferutil
-      - msw
-      - utf-8-validate
-      - vite
-
   '@vitest/browser@3.2.4(playwright@1.61.1)(vite@7.2.4(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -12450,6 +11061,24 @@ snapshots:
       - utf-8-validate
       - vite
 
+  '@vitest/browser@3.2.4(vite@7.2.4(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
+      '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))
+      '@vitest/utils': 3.2.4
+      magic-string: 0.30.21
+      sirv: 3.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/browser@3.2.4)(jiti@2.7.0)(jsdom@27.2.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser@3.2.4(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -12459,7 +11088,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/browser@3.2.4)(jiti@2.7.0)(jsdom@27.2.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@26.1.2)(@vitest/browser@3.2.4)(jiti@2.7.0)(jsdom@27.2.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -12483,14 +11112,6 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.2.4(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0)
-
-  '@vitest/mocker@3.2.4(vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
 
   '@vitest/mocker@3.2.4(vite@7.2.4(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))':
     dependencies:
@@ -12738,15 +11359,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0):
-    dependencies:
-      '@babel/compat-data': 7.29.3
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -12756,26 +11368,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
-      core-js-compat: 3.49.0
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
       core-js-compat: 3.49.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12804,50 +11401,11 @@ snapshots:
     dependencies:
       hermes-parser: 0.33.3
 
-  babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.0):
-    dependencies:
-      '@babel/plugin-syntax-flow': 7.28.6(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-
   babel-plugin-transform-flow-enums@0.0.2(@babel/core@7.29.7):
     dependencies:
       '@babel/plugin-syntax-flow': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - '@babel/core'
-
-  babel-preset-expo@55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-refresh@0.14.2):
-    dependencies:
-      '@babel/generator': 7.29.1
-      '@babel/helper-module-imports': 7.28.6
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-proposal-export-default-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-syntax-export-default-from': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.0)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
-      '@react-native/babel-preset': 0.83.6(@babel/core@7.29.0)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.2
-      babel-plugin-syntax-hermes-parser: 0.32.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.0)
-      debug: 4.4.3(supports-color@8.1.1)
-      react-refresh: 0.14.2
-      resolve-from: 5.0.0
-    optionalDependencies:
-      '@babel/runtime': 7.29.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
 
   babel-preset-expo@55.0.24(@babel/core@7.29.7)(@babel/runtime@7.29.7)(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-refresh@0.14.2):
     dependencies:
@@ -13404,8 +11962,6 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
-  dnssd-advertise@1.1.4: {}
-
   dnssd-advertise@1.1.6: {}
 
   doctrine@2.1.0:
@@ -13902,17 +12458,6 @@ snapshots:
 
   expect-type@1.2.2: {}
 
-  expo-asset@55.0.17(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3):
-    dependencies:
-      '@expo/image-utils': 0.8.14(typescript@5.8.3)
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      expo-constants: 55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   expo-asset@55.0.18(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3):
     dependencies:
       '@expo/image-utils': 0.8.15(typescript@5.8.3)
@@ -13924,14 +12469,6 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-constants@55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)):
-    dependencies:
-      '@expo/env': 2.1.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-    transitivePeerDependencies:
-      - supports-color
-
   expo-constants@55.0.17(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)):
     dependencies:
       '@expo/env': 2.1.3
@@ -13939,11 +12476,6 @@ snapshots:
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
-
-  expo-file-system@55.0.19(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)):
-    dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
 
   expo-file-system@55.0.19(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)):
     dependencies:
@@ -13955,24 +12487,12 @@ snapshots:
       expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
 
-  expo-font@55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
-    dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      fontfaceobserver: 2.3.0
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-
   expo-font@55.0.8(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
     dependencies:
       expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
       fontfaceobserver: 2.3.0
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
-
-  expo-keep-awake@55.0.8(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react@19.2.0):
-    dependencies:
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react: 19.2.0
 
   expo-keep-awake@55.0.8(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react@19.2.0):
     dependencies:
@@ -13989,12 +12509,6 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
-    dependencies:
-      invariant: 2.2.4
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-
   expo-modules-core@55.0.25(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
     dependencies:
       invariant: 2.2.4
@@ -14003,62 +12517,12 @@ snapshots:
 
   expo-server@55.0.11: {}
 
-  expo-server@55.0.9: {}
-
-  expo-sqlite@55.0.15(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
-    dependencies:
-      await-lock: 2.2.2
-      expo: 55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-
   expo-sqlite@55.0.15(expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0):
     dependencies:
       await-lock: 2.2.2
       expo: 55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
       react: 19.2.0
       react-native: 0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0)
-
-  expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@expo/cli': 55.0.29(bfd3siqyehv3mcoji6txwhfafu)
-      '@expo/config': 55.0.16(typescript@5.8.3)
-      '@expo/config-plugins': 55.0.8
-      '@expo/devtools': 55.0.3(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      '@expo/fingerprint': 0.16.7
-      '@expo/local-build-cache-provider': 55.0.12(typescript@5.8.3)
-      '@expo/log-box': 55.0.12(@expo/dom-webview@55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      '@expo/metro': 55.1.1
-      '@expo/metro-config': 55.0.20(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(typescript@5.8.3)
-      '@expo/vector-icons': 15.1.1(expo-font@55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      '@ungap/structured-clone': 1.3.1
-      babel-preset-expo: 55.0.21(@babel/core@7.29.0)(@babel/runtime@7.29.2)(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-refresh@0.14.2)
-      expo-asset: 55.0.17(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3)
-      expo-constants: 55.0.16(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))
-      expo-file-system: 55.0.19(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))
-      expo-font: 55.0.7(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      expo-keep-awake: 55.0.8(expo@55.0.23(@babel/core@7.29.0)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3))(react@19.2.0)
-      expo-modules-autolinking: 55.0.21(typescript@5.8.3)
-      expo-modules-core: 55.0.25(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      pretty-format: 29.7.0
-      react: 19.2.0
-      react-native: 0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0)
-      react-refresh: 0.14.2
-      whatwg-url-minimum: 0.1.1
-    optionalDependencies:
-      '@expo/dom-webview': 55.0.6(expo@55.0.23)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - expo-widgets
-      - react-dom
-      - react-native-worklets
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
 
   expo@55.0.23(@babel/core@7.29.7)(@expo/dom-webview@55.0.6)(react-dom@19.2.0(react@19.2.0))(react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)(typescript@5.8.3):
     dependencies:
@@ -14980,16 +13444,10 @@ snapshots:
   lightningcss-android-arm64@1.30.2:
     optional: true
 
-  lightningcss-android-arm64@1.32.0:
-    optional: true
-
   lightningcss-android-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-arm64@1.30.2:
-    optional: true
-
-  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-arm64@1.33.0:
@@ -14998,16 +13456,10 @@ snapshots:
   lightningcss-darwin-x64@1.30.2:
     optional: true
 
-  lightningcss-darwin-x64@1.32.0:
-    optional: true
-
   lightningcss-darwin-x64@1.33.0:
     optional: true
 
   lightningcss-freebsd-x64@1.30.2:
-    optional: true
-
-  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-freebsd-x64@1.33.0:
@@ -15016,16 +13468,10 @@ snapshots:
   lightningcss-linux-arm-gnueabihf@1.30.2:
     optional: true
 
-  lightningcss-linux-arm-gnueabihf@1.32.0:
-    optional: true
-
   lightningcss-linux-arm-gnueabihf@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.30.2:
-    optional: true
-
-  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-gnu@1.33.0:
@@ -15034,16 +13480,10 @@ snapshots:
   lightningcss-linux-arm64-musl@1.30.2:
     optional: true
 
-  lightningcss-linux-arm64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-arm64-musl@1.33.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.30.2:
-    optional: true
-
-  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-gnu@1.33.0:
@@ -15052,25 +13492,16 @@ snapshots:
   lightningcss-linux-x64-musl@1.30.2:
     optional: true
 
-  lightningcss-linux-x64-musl@1.32.0:
-    optional: true
-
   lightningcss-linux-x64-musl@1.33.0:
     optional: true
 
   lightningcss-win32-arm64-msvc@1.30.2:
     optional: true
 
-  lightningcss-win32-arm64-msvc@1.32.0:
-    optional: true
-
   lightningcss-win32-arm64-msvc@1.33.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.30.2:
-    optional: true
-
-  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss-win32-x64-msvc@1.33.0:
@@ -15091,22 +13522,6 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.2
       lightningcss-win32-arm64-msvc: 1.30.2
       lightningcss-win32-x64-msvc: 1.30.2
-
-  lightningcss@1.32.0:
-    dependencies:
-      detect-libc: 2.1.2
-    optionalDependencies:
-      lightningcss-android-arm64: 1.32.0
-      lightningcss-darwin-arm64: 1.32.0
-      lightningcss-darwin-x64: 1.32.0
-      lightningcss-freebsd-x64: 1.32.0
-      lightningcss-linux-arm-gnueabihf: 1.32.0
-      lightningcss-linux-arm64-gnu: 1.32.0
-      lightningcss-linux-arm64-musl: 1.32.0
-      lightningcss-linux-x64-gnu: 1.32.0
-      lightningcss-linux-x64-musl: 1.32.0
-      lightningcss-win32-arm64-msvc: 1.32.0
-      lightningcss-win32-x64-msvc: 1.32.0
 
   lightningcss@1.33.0:
     dependencies:
@@ -16512,51 +14927,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0):
-    dependencies:
-      '@react-native/assets-registry': 0.85.3
-      '@react-native/codegen': 0.85.3(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.85.3
-      '@react-native/gradle-plugin': 0.85.3
-      '@react-native/js-polyfills': 0.85.3
-      '@react-native/normalize-colors': 0.85.3
-      '@react-native/virtualized-lists': 0.85.3(@types/react@19.2.6)(react-native@0.85.3(@babel/core@7.29.0)(@types/react@19.2.6)(react@19.2.0))(react@19.2.0)
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      ansi-regex: 5.0.1
-      babel-plugin-syntax-hermes-parser: 0.33.3
-      base64-js: 1.5.1
-      commander: 12.1.0
-      flow-enums-runtime: 0.0.6
-      hermes-compiler: 250829098.0.10
-      invariant: 2.2.4
-      memoize-one: 5.2.1
-      metro-runtime: 0.84.4
-      metro-source-map: 0.84.4
-      nullthrows: 1.1.1
-      pretty-format: 29.7.0
-      promise: 8.3.0
-      react: 19.2.0
-      react-devtools-core: 6.1.5
-      react-refresh: 0.14.2
-      regenerator-runtime: 0.13.11
-      scheduler: 0.27.0
-      semver: 7.7.4
-      stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
-      whatwg-fetch: 3.6.20
-      ws: 7.5.10
-      yargs: 17.7.2
-    optionalDependencies:
-      '@types/react': 19.2.6
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@react-native-community/cli'
-      - '@react-native/metro-config'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   react-native@0.85.3(@babel/core@7.29.7)(@types/react@19.2.6)(react@19.2.0):
     dependencies:
       '@react-native/assets-registry': 0.85.3
@@ -17295,14 +15665,6 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser@5.46.2:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.18.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
-
   terser@5.49.0:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -17539,9 +15901,6 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2:
-    optional: true
-
   undici-types@8.3.0:
     optional: true
 
@@ -17671,27 +16030,6 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@26.1.2)(jiti@2.6.1)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -17748,23 +16086,6 @@ snapshots:
       jiti: 2.7.0
       lightningcss: 1.33.0
       terser: 5.49.0
-      tsx: 4.20.6
-      yaml: 2.9.0
-
-  vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0):
-    dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.53.3
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 25.6.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.32.0
-      terser: 5.46.2
       tsx: 4.20.6
       yaml: 2.9.0
 
@@ -17834,51 +16155,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 24.10.1
-      '@vitest/browser': 3.2.4(vitest@3.2.4)
-      jsdom: 27.2.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.6.0)(@vitest/browser@3.2.4)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3(supports-color@8.1.1)
-      expect-type: 1.2.2
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.16
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.2)(tsx@4.20.6)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 25.6.0
-      '@vitest/browser': 3.2.4(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(vite@7.2.4(@types/node@24.10.1)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)
       jsdom: 27.2.0
     transitivePeerDependencies:
       - jiti
@@ -17966,7 +16243,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 26.1.2
-      '@vitest/browser': 3.2.4(playwright@1.61.1)(vite@7.2.4(@types/node@26.1.2)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.49.0)(tsx@4.20.6)(yaml@2.9.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(vitest@3.2.4)
       jsdom: 27.2.0
     transitivePeerDependencies:
       - jiti
@@ -18014,8 +16291,6 @@ snapshots:
 
   whatwg-mimetype@5.0.0:
     optional: true
-
-  whatwg-url-minimum@0.1.1: {}
 
   whatwg-url-minimum@0.1.2: {}
 
@@ -18101,8 +16376,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
-
-  ws@7.5.10: {}
 
   ws@7.5.13: {}
 


### PR DESCRIPTION
## Summary
- Extend canonical ontology metadata with stable IDs, title properties, link cardinality, and backend link fallback support.
- Add static metadata/pull APIs, confidential authentication, normalized Foundry errors, RID-aware metadata queries, and unredacted action metadata.
- Add LiveOntology link traversal and Foundry attachment/media metadata support.
- Add package changesets and regression coverage across ontology, foundry-client, and foundry-ontology.

No [Streamline](https://github.com/valinor-enterprises/streamline) files are changed; this PR provides the upstream APIs required for the subsequent Gateway port.

## Follow-up
- Preserve extended media metadata after BlobManager caches remote content.
- Publish these releases for use in Streamline
- Streamline Gateway updates