### PR TITLE
Add runtime Action type IDs

### DIFF
--- a/.changeset/meta-action-runtime-identity.md
+++ b/.changeset/meta-action-runtime-identity.md
@@ -1,0 +1,8 @@
+---
+"@party-stack/ontology": minor
+"@party-stack/foundry-ontology": minor
+---
+
+Add required action type identifiers to runtime metadata while keeping portable action definitions provider-neutral.
+
+Map Foundry action type RIDs into runtime metadata and support filtering the ActionType collection by ID.

--- a/packages/foundry-ontology/src/meta/actionTypeIdQuery.test.ts
+++ b/packages/foundry-ontology/src/meta/actionTypeIdQuery.test.ts
@@ -1,0 +1,96 @@
+import { createMetaLiveOntology } from "@party-stack/ontology";
+import { eq, queryOnce } from "@tanstack/db";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OntologyClient } from "@party-stack/foundry-client";
+import { createFoundryMetaOntologyBackendAdapter } from "./createFoundryMetaOntologyBackendAdapter.js";
+
+const mocks = vi.hoisted(() => ({
+    getFullMetadata: vi.fn(),
+    searchActionTypes: vi.fn(),
+}));
+
+vi.mock("@osdk/foundry.ontologies", async (importOriginal) => {
+    const original = await importOriginal<typeof import("@osdk/foundry.ontologies")>();
+    return {
+        ...original,
+        ActionTypesV2: {
+            ...original.ActionTypesV2,
+            search: mocks.searchActionTypes,
+        },
+        OntologiesV2: {
+            ...original.OntologiesV2,
+            getFullMetadata: mocks.getFullMetadata,
+        },
+    };
+});
+
+const client: OntologyClient = {
+    baseUrl: "https://foundry.example.com",
+    ontologyRid: "ri.ontology.main.ontology.example",
+    tokenProvider: () => Promise.resolve("token"),
+    fetch: globalThis.fetch,
+};
+
+beforeEach(() => {
+    mocks.getFullMetadata.mockReset();
+    mocks.searchActionTypes.mockReset();
+    mocks.getFullMetadata.mockResolvedValue({
+        objectTypes: {},
+        valueTypes: {},
+    });
+});
+
+describe("Foundry ActionType metadata ID queries", () => {
+    it("pushes an ID predicate into ActionTypesV2.search", async () => {
+        mocks.searchActionTypes.mockResolvedValue({
+            data: [
+                {
+                    apiName: "create-task",
+                    displayName: "Create task",
+                    status: "ACTIVE",
+                    parameters: {},
+                    rid: "ri.actions.main.action-type.create-task",
+                    operations: [],
+                },
+            ],
+            nextPageToken: undefined,
+        });
+        const meta = await createMetaLiveOntology({
+            backend: () => createFoundryMetaOntologyBackendAdapter({ client }),
+            persistObjects: false,
+        });
+
+        try {
+            const rows = await queryOnce((q) =>
+                q
+                    .from({ ActionType: meta.objects.ActionType })
+                    .where(({ ActionType }) =>
+                        eq(
+                            ActionType.id,
+                            "ri.actions.main.action-type.create-task"
+                        )
+                    )
+            );
+
+            expect(mocks.searchActionTypes).toHaveBeenCalledWith(
+                expect.anything(),
+                "ri.ontology.main.ontology.example",
+                expect.objectContaining({
+                    where: {
+                        type: "actionTypeRid",
+                        value: "ri.actions.main.action-type.create-task",
+                    },
+                }),
+                { preview: true }
+            );
+            expect(rows).toEqual([
+                expect.objectContaining({
+                    id: "ri.actions.main.action-type.create-task",
+                    name: "createTask",
+                }),
+            ]);
+        } finally {
+            await meta.cleanup();
+        }
+    });
+});

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
@@ -67,6 +67,17 @@ describe("convertActionTypeLoadSubsetFilter", () => {
         });
     });
 
+    it("rejects LIKE predicates for ID fields", () => {
+        expect(() =>
+            convertActionTypeLoadSubsetFilter(
+                like(
+                    new IR.PropRef<string>(["id"]),
+                    "%ri.actions.main.action-type%"
+                )
+            )
+        ).toThrow(/does not support LIKE filtering/);
+    });
+
     it("converts each like wildcard-delimited term to a contains predicate", () => {
         expect(
             convertActionTypeLoadSubsetFilter(

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.test.ts
@@ -6,6 +6,20 @@ import {
 } from "./convertActionTypeLoadSubsetOptions.js";
 
 describe("convertActionTypeLoadSubsetFilter", () => {
+    it("converts id equality to an exact RID predicate", () => {
+        expect(
+            convertActionTypeLoadSubsetFilter(
+                eq(
+                    new IR.PropRef<string>(["id"]),
+                    "ri.actions.main.action-type.create-task"
+                )
+            )
+        ).toEqual({
+            type: "actionTypeRid",
+            value: "ri.actions.main.action-type.create-task",
+        });
+    });
+
     it("converts name equality to an exact apiName predicate with kebab-case", () => {
         const filter = convertActionTypeLoadSubsetFilter(
             eq(new IR.PropRef<string>(["name"]), "streamlineCreateToken")

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
@@ -13,6 +13,11 @@ const FILTER_FIELDS = {
     displayName: "actionTypeDisplayName",
 } as const satisfies Partial<Record<keyof MetaActionType, ActionTypeSearchJsonQueryV2["type"]>>;
 
+const LIKE_FIELDS = {
+    name: FILTER_FIELDS.name,
+    displayName: FILTER_FIELDS.displayName,
+} as const satisfies Pick<typeof FILTER_FIELDS, "name" | "displayName">;
+
 const ORDER_BY_FIELDS = {
     displayName: "actionTypeDisplayName",
 } as const satisfies Partial<Record<keyof MetaActionType, ActionTypeSortByV2>>;
@@ -23,6 +28,14 @@ function getFilterField(field: FieldPath): keyof typeof FILTER_FIELDS {
         return name as keyof typeof FILTER_FIELDS;
     }
     throw new Error(`Foundry ActionType search does not support filtering by "${name}".`);
+}
+
+function getLikeField(field: FieldPath): keyof typeof LIKE_FIELDS {
+    const name = field.join(".");
+    if (name && Object.hasOwn(LIKE_FIELDS, name)) {
+        return name as keyof typeof LIKE_FIELDS;
+    }
+    throw new Error(`Foundry ActionType search does not support LIKE filtering by "${name}".`);
 }
 
 function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
@@ -43,13 +56,10 @@ function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
 }
 
 function like(field: FieldPath, value: string): ActionTypeSearchJsonQueryV2 {
-    const name = getFilterField(field);
-    if (name === "id") {
-        throw new Error("Foundry ActionType search only supports exact filtering by id.");
-    }
+    const name = getLikeField(field);
     const terms = value.split("%").filter(Boolean);
     const queries: ActionTypeSearchJsonQueryV2[] = terms.map((term) => ({
-        type: FILTER_FIELDS[name],
+        type: LIKE_FIELDS[name],
         value: {
             type: "contains",
             value: name === "name" ? toFoundryActionTypeName(term) : term,

--- a/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
+++ b/packages/foundry-ontology/src/meta/convertActionTypeLoadSubsetOptions.ts
@@ -8,6 +8,7 @@ import type {
 } from "@osdk/foundry.ontologies";
 
 const FILTER_FIELDS = {
+    id: "actionTypeRid",
     name: "actionTypeApiName",
     displayName: "actionTypeDisplayName",
 } as const satisfies Partial<Record<keyof MetaActionType, ActionTypeSearchJsonQueryV2["type"]>>;
@@ -26,6 +27,12 @@ function getFilterField(field: FieldPath): keyof typeof FILTER_FIELDS {
 
 function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
     const name = getFilterField(field);
+    if (name === "id") {
+        return {
+            type: "actionTypeRid",
+            value: value as string,
+        };
+    }
     return {
         type: FILTER_FIELDS[name],
         value: {
@@ -37,6 +44,9 @@ function eq(field: FieldPath, value: unknown): ActionTypeSearchJsonQueryV2 {
 
 function like(field: FieldPath, value: string): ActionTypeSearchJsonQueryV2 {
     const name = getFilterField(field);
+    if (name === "id") {
+        throw new Error("Foundry ActionType search only supports exact filtering by id.");
+    }
     const terms = value.split("%").filter(Boolean);
     const queries: ActionTypeSearchJsonQueryV2[] = terms.map((term) => ({
         type: FILTER_FIELDS[name],

--- a/packages/foundry-ontology/src/meta/convertMetaActionType.test.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaActionType.test.ts
@@ -17,6 +17,13 @@ function actionType(parameters: Record<string, ActionParameterV2>): ActionTypeFu
 }
 
 describe("convertFoundryMetaActionType parameter validation", () => {
+    it("maps the Foundry action type RID to the runtime metadata ID", () => {
+        expect(convertFoundryMetaActionType(actionType({}))).toMatchObject({
+            id: "ri.actions.main.action-type.example",
+            name: "validatedAction",
+        });
+    });
+
     it("converts closed one-of string validation to an enum constraint", () => {
         const result = convertFoundryMetaActionType(
             actionType({

--- a/packages/foundry-ontology/src/meta/convertMetaActionType.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaActionType.ts
@@ -3,6 +3,7 @@ import type {
     ActionParameterDef,
     ActionTypeDef,
     Expression,
+    MetaActionType,
     PropertyAssignment,
     StringConstraint,
     TypeDef,
@@ -475,13 +476,14 @@ function convertLogicStep(
     }
 }
 
-export function convertFoundryMetaActionType(actionType: ActionTypeFullMetadata): ActionTypeDef {
+export function convertFoundryMetaActionType(actionType: ActionTypeFullMetadata): MetaActionType {
     const syntheticParameters = createSyntheticParameters(actionType);
     const fullLogicRules = actionType.fullLogicRules
         .map((rule) => convertLogicStep(rule, syntheticParameters))
         .filter((rule): rule is NonNullable<typeof rule> => rule !== null);
 
     return {
+        id: actionType.actionType.rid,
         name: toOntologyActionTypeName(actionType.actionType.apiName),
         displayName: actionType.actionType.displayName ?? actionType.actionType.apiName,
         description: actionType.actionType.description,

--- a/packages/ontology/src/meta/generated/types.ts
+++ b/packages/ontology/src/meta/generated/types.ts
@@ -313,6 +313,8 @@ export type LinkType = {
 
 /** An action type in the ontology. */
 export type ActionType = {
+    /** The provider-assigned stable identifier for this action type. */
+    id: string;
     /** The object type's programmatic name. */
     name: string;
     /** Human-readable name. */

--- a/packages/ontology/src/meta/ontology.test.ts
+++ b/packages/ontology/src/meta/ontology.test.ts
@@ -10,11 +10,21 @@ describe("meta ontology runtime fields", () => {
         const property = canonicalOntology.types.find(
             (type) => type.name === "PropertyDef"
         );
+        const actionType = canonicalOntology.types.find(
+            (type) => type.name === "ActionTypeDef"
+        );
 
         expect(objectType?.type.kind).toBe("struct");
         expect(property?.type.kind).toBe("struct");
-        if (objectType?.type.kind !== "struct" || property?.type.kind !== "struct") {
-            throw new Error("Expected canonical object and property definitions to be structs.");
+        expect(actionType?.type.kind).toBe("struct");
+        if (
+            objectType?.type.kind !== "struct" ||
+            property?.type.kind !== "struct" ||
+            actionType?.type.kind !== "struct"
+        ) {
+            throw new Error(
+                "Expected canonical object, property, and action definitions to be structs."
+            );
         }
 
         expect(objectType.type.value.fields.map(({ name }) => name)).not.toContain("id");
@@ -23,6 +33,7 @@ describe("meta ontology runtime fields", () => {
             value: { type: { kind: "string", value: {} } },
         });
         expect(property.type.value.fields.map(({ name }) => name)).not.toContain("id");
+        expect(actionType.type.value.fields.map(({ name }) => name)).not.toContain("id");
     });
 
     it("requires IDs while preserving the canonical title field in runtime metadata", () => {
@@ -31,6 +42,9 @@ describe("meta ontology runtime fields", () => {
         );
         const property = metaOntology.types.find(
             (type) => type.name === "PropertyDef"
+        );
+        const actionType = metaOntology.objectTypes.find(
+            (type) => type.name === "ActionType"
         );
 
         expect(objectType?.properties.find(({ name }) => name === "id")?.type).toEqual({
@@ -49,6 +63,10 @@ describe("meta ontology runtime fields", () => {
             throw new Error("Expected runtime PropertyDef to be a struct.");
         }
         expect(property.type.value.fields.find(({ name }) => name === "id")?.type).toEqual({
+            kind: "string",
+            value: {},
+        });
+        expect(actionType?.properties.find(({ name }) => name === "id")?.type).toEqual({
             kind: "string",
             value: {},
         });

--- a/packages/ontology/src/meta/ontology.ts
+++ b/packages/ontology/src/meta/ontology.ts
@@ -38,6 +38,11 @@ function addRuntimeMetaFields(type: NamedTypeDef): NamedTypeDef {
             type,
             "The provider-assigned stable identifier for this property."
         );
+    } else if (type.name === "ActionTypeDef") {
+        return addRuntimeId(
+            type,
+            "The provider-assigned stable identifier for this action type."
+        );
     } else {
         return type;
     }


### PR DESCRIPTION
## Summary
- Add required IDs to lifted `MetaActionType` metadata while keeping portable `ActionTypeDef` definitions provider-neutral.
- Map Foundry action type RIDs into runtime metadata.
- Support TanStack queries against `ActionType.id` through Foundry’s `actionTypeRid` search filter.

Gateway stores selected actions and token policy references as Foundry RIDs. This allows Gateway to resolve those RIDs through Party Stack metadata, pull the corresponding action by name, and execute it through LiveOntology without calling the extended Foundry client directly.
