### PR TITLE
Continue migrating gateway

### DIFF
--- a/.changeset/liveontology-default-runtime.md
+++ b/.changeset/liveontology-default-runtime.md
@@ -1,0 +1,9 @@
+---
+"@party-stack/ontology": minor
+"@party-stack/blobs": patch
+"@party-stack/remote-ontology": minor
+"@party-stack/foundry-ontology": minor
+"@party-stack/sqlite-ontology": minor
+---
+
+OSDK-free LiveOntology Gateway MVP: collection readiness and race-safe cleanup, non-blocking action refresh, structured remote errors, policy-aware describe projection, precise invalidation, attachments, and public Foundry action metadata. No generic link traversal, object-query helpers, or OMS/prefill metadata.

--- a/docs/liveontology-default-runtime-migration.md
+++ b/docs/liveontology-default-runtime-migration.md
@@ -1,0 +1,33 @@
+# Streamline workaround removal matrix (OSDK-free Gateway MVP)
+
+After consuming this Party Stack release, Streamline can remove or retain the following LiveOntology workarounds:
+
+| Streamline code | Status | Notes |
+| --- | --- | --- |
+| `startBackendCollectionSync` | Removable | Remote/Foundry servers now start on-demand sync via `waitForLiveOntologyReady` / `startSyncImmediate` without issuing subset loads. |
+| `createGatewayRemoteOntologyBackend` (readiness/cast hacks) | Removable | Use stock remote client/server readiness + structured errors. |
+| Downstream `projectClientIr` object/property/link projection | Removable | Use remote `projectRemoteOntologyIR` with `schemaProjectionMode: "authorized"` and policy `allowedObjectTypeProperties` / visibility hooks. |
+| Session-stable cleanup races | Mostly removable | Party Stack cleanup is single-flight and initialization-aware. Retain Streamline session/token lifecycle if product-specific. |
+| FK-only `liveLinkAccess` helpers | Keep | Party Stack does not provide generic link traversal. Streamline continues FK-backed TanStack joins and fails closed for non-FK links. |
+| OMS edit-prefill OSDK / private OMS metadata path | Keep | Public `ActionTypesFullMetadata` does not expose OMS UI prefills. Party Stack does not call private OMS Conjure endpoints or guess prefills. |
+| Object-query helper / `resolveActionPrefills` fallbacks | Keep | Not provided by Party Stack. Query `LiveOntology.objects` with TanStack DB for direct object references. |
+| Security policy / revision / token integration | Keep | Product-specific; not replaced by Party Stack. |
+
+## Explicitly unsupported in this MVP
+
+- Non-FK / object-backed / many-to-many link traversal
+- OMS-specific static UI defaults and object-property / object-query / object-set prefills
+- Private Foundry OMS APIs (`/ontology-metadata/api`, `bulkLoadOntologyEntities`, wire metadata)
+- Generic query functions without a backend-registered implementation
+- Remote `resolve-link`
+
+## Supported MVP surface
+
+- Primitive, struct/list, and direct object-reference action parameters
+- Existing FK-backed link metadata
+- Fixed action parameter values (remote policy)
+- Basic object/property security policies
+- Attachments and action submission
+- SQLite-backed demo environments
+- Public Foundry APIs when Foundry is the backend
+- Generic IR `defaultValue` expressions (including generated UUID / current-time)

--- a/packages/blobs/src/createBlobManager.ts
+++ b/packages/blobs/src/createBlobManager.ts
@@ -316,6 +316,7 @@ export function createBlobManager(options: BlobManagerOptions): BlobManager {
     let cleanupPromise: Promise<void> | undefined;
     return {
         collection: store.collection,
+        ready: store.ready,
 
         async stage(id, blob) {
             await store.stage(id, blob);
@@ -332,11 +333,13 @@ export function createBlobManager(options: BlobManagerOptions): BlobManager {
         },
 
         cleanup() {
-            cleanupPromise ??= Promise.resolve(lifetime.halt())
-                .catch(ignoreEffectionHalt)
-                .then(() => {
-                    return store.cleanup();
-                });
+            cleanupPromise ??= (async () => {
+                // Settle persistence startup before tearing down so loopback
+                // markReady cannot race a cleaned-up collection.
+                await Promise.allSettled([store.ready]);
+                await Promise.resolve(lifetime.halt()).catch(ignoreEffectionHalt);
+                await store.cleanup();
+            })();
             return cleanupPromise;
         },
     };

--- a/packages/blobs/src/store/createBlobStore.test.ts
+++ b/packages/blobs/src/store/createBlobStore.test.ts
@@ -549,4 +549,22 @@ describe("createBlobStore", () => {
         );
         await store.cleanup();
     });
+
+    it("settles immediate and repeated cleanup during persistence startup", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => {
+            unhandled.push(reason);
+        };
+        process.on("unhandledRejection", onUnhandled);
+
+        try {
+            const { store } = setup();
+            await expect(Promise.all([store.ready, store.cleanup()])).resolves.toBeDefined();
+            await expect(store.cleanup()).resolves.toBeUndefined();
+            expect(store.collection.status).toBe("cleaned-up");
+            expect(unhandled).toEqual([]);
+        } finally {
+            process.off("unhandledRejection", onUnhandled);
+        }
+    });
 });

--- a/packages/blobs/src/store/createBlobStore.ts
+++ b/packages/blobs/src/store/createBlobStore.ts
@@ -158,11 +158,17 @@ export function createBlobStore(options: CreateBlobStoreOptions): BlobStore {
         runtime: options.runtime,
         schemaVersion: 2,
     });
-    const ready = collection.preload();
+    // Suppress unhandled rejection if cleanup races persistence startup.
+    const ready = collection.preload().catch((error) => {
+        if (collection.status === "cleaned-up") return;
+        throw error;
+    });
+    void ready.catch(() => undefined);
     const bytes = options.runtime.blobBytes;
     const activeOperationIds = new Set<string>();
     const client = options.runtime.coordination.service<BlobCoordinationService>(BLOB_COORDINATION_SERVICE);
     let activeRecoveryId: string | undefined;
+    let disposing = false;
 
     const findRef = async (id: string): Promise<BlobMetadataRecord | undefined> => {
         await ready;
@@ -597,7 +603,12 @@ export function createBlobStore(options: CreateBlobStoreOptions): BlobStore {
     return {
         collection,
         ready,
-        beginWrite: (input) => client.methods.beginWrite(input),
+        beginWrite: (input) => {
+            if (disposing) {
+                return Promise.reject(new Error("Blob store is disposing."));
+            }
+            return client.methods.beginWrite(input);
+        },
         commitWrite: (input) => client.methods.commitWrite(input),
         failWrite: (input) => client.methods.failWrite(input),
         stage: (id, blob) => write(id, blob, "stage"),
@@ -656,9 +667,15 @@ export function createBlobStore(options: CreateBlobStoreOptions): BlobStore {
         },
         cleanup() {
             cleanupPromise ??= (async () => {
+                disposing = true;
                 activeOperationIds.clear();
+                // Await persistence startup before cleaning the collection so
+                // TanStack loopback cannot call markReady after cleaned-up.
+                await Promise.allSettled([ready]);
                 await server?.close();
-                await collection.cleanup();
+                if (collection.status !== "cleaned-up") {
+                    await collection.cleanup();
+                }
             })();
             return cleanupPromise;
         },

--- a/packages/blobs/src/types.ts
+++ b/packages/blobs/src/types.ts
@@ -62,6 +62,8 @@ export interface BlobRemoteSource {
 
 export interface BlobManager {
     readonly collection: Collection<BlobMetadataRecord, string>;
+    /** Resolves once blob metadata persistence has finished starting. */
+    readonly ready: Promise<void>;
     stage: (id: string, blob: Blob | File) => Promise<void>;
     metadata: (
         id: string,

--- a/packages/foundry-ontology/README.md
+++ b/packages/foundry-ontology/README.md
@@ -1,1 +1,18 @@
 # foundry-ontology
+
+Foundry adapter and metadata conversion for Party Stack LiveOntology.
+
+## Link metadata
+
+- Only FK-backed Foundry links are converted into Party Stack IR.
+- Non-FK / object-backed links are omitted (unsupported; no synthetic FK).
+
+## Action metadata
+
+Uses public Foundry APIs (`ActionTypesV2` / `ActionTypesFullMetadata`):
+
+- Action parameter and type conversion
+- Full logic-rule conversion
+- Synthetic UUID / current-time default parameters from public logic metadata
+
+OMS UI edit-prefill metadata is not available from public APIs and is not converted.

--- a/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.ts
+++ b/packages/foundry-ontology/src/adapter/createFoundryOntologyBackendAdapter.ts
@@ -328,7 +328,8 @@ export function createFoundryOntologyBackendAdapter(opts: {
             }
             if (context) {
                 const operationId = getApplyActionOperationId(result);
-                const targetCollections = Array.from(getEditedObjectTypes(result.edits))
+                const editedObjectTypes = Array.from(getEditedObjectTypes(result.edits));
+                const targetCollections = editedObjectTypes
                     .map((objectType) => context.objects[objectType] as CollectionWithUtils | undefined)
                     .filter((collection): collection is CollectionWithUtils =>
                         Boolean(collection?.utils?.awaitOperationId)
@@ -337,8 +338,22 @@ export function createFoundryOntologyBackendAdapter(opts: {
                 await Promise.all(
                     targetCollections.map((collection) => collection.utils.awaitOperationId(operationId))
                 );
+
+                return {
+                    ...(editedObjectTypes.length > 0
+                        ? { invalidatedObjectTypes: editedObjectTypes }
+                        : {}),
+                    ...(attachmentIdMappings.length > 0 ? { attachmentIdMappings } : {}),
+                };
             }
-            return attachmentIdMappings.length > 0 ? { attachmentIdMappings } : undefined;
+            const editedObjectTypes = Array.from(getEditedObjectTypes(result.edits));
+            if (editedObjectTypes.length === 0 && attachmentIdMappings.length === 0) {
+                return undefined;
+            }
+            return {
+                ...(editedObjectTypes.length > 0 ? { invalidatedObjectTypes: editedObjectTypes } : {}),
+                ...(attachmentIdMappings.length > 0 ? { attachmentIdMappings } : {}),
+            };
         },
         runQueryFunction: async (name, parameters) => {
             const queryFunctionType = opts.ir.queryFunctionTypes.find((candidate) => candidate.name === name);

--- a/packages/foundry-ontology/src/meta/convertMetaLinkType.test.ts
+++ b/packages/foundry-ontology/src/meta/convertMetaLinkType.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { convertFoundryMetaLinkTypes } from "./convertMetaLinkType.js";
+import type { ObjectTypeFullMetadata } from "@osdk/foundry.ontologies";
+
+function objectType(opts: {
+    apiName: string;
+    linkTypes: ObjectTypeFullMetadata["linkTypes"];
+}): ObjectTypeFullMetadata {
+    return {
+        objectType: {
+            apiName: opts.apiName,
+            displayName: opts.apiName,
+            status: "ACTIVE",
+            description: undefined,
+            pluralDisplayName: `${opts.apiName}s`,
+            primaryKey: "id",
+            properties: {
+                id: {
+                    dataType: { type: "string" },
+                    rid: `ri.ontology.main.property.${opts.apiName}.id`,
+                    apiName: "id",
+                    displayName: "ID",
+                    status: "ACTIVE",
+                    visibility: "NORMAL",
+                },
+            },
+            rid: `ri.ontology.main.object-type.${opts.apiName}`,
+            titleProperty: "id",
+        },
+        linkTypes: opts.linkTypes,
+        sharedPropertyTypeMapping: {},
+        implementsInterfaces: [],
+        implementsInterfaces2: {},
+    } as unknown as ObjectTypeFullMetadata;
+}
+
+describe("convertFoundryMetaLinkTypes", () => {
+    it("converts FK-backed links", () => {
+        const linkRid = "ri.ontology.main.link-type.post-author";
+        const result = convertFoundryMetaLinkTypes([
+            objectType({
+                apiName: "Post",
+                linkTypes: [
+                    {
+                        apiName: "posts",
+                        displayName: "Posts",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Post",
+                        cardinality: "MANY",
+                        foreignKeyPropertyApiName: "authorId",
+                        linkTypeRid: linkRid,
+                    },
+                ],
+            }),
+            objectType({
+                apiName: "Author",
+                linkTypes: [
+                    {
+                        apiName: "author",
+                        displayName: "Author",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Author",
+                        cardinality: "ONE",
+                        linkTypeRid: linkRid,
+                    },
+                ],
+            }),
+        ]);
+
+        expect(result).toEqual([
+            {
+                id: linkRid,
+                source: {
+                    objectType: "Post",
+                    name: "posts",
+                    displayName: "Posts",
+                },
+                target: {
+                    objectType: "Author",
+                    name: "author",
+                    displayName: "Author",
+                },
+                foreignKey: "authorId",
+                cardinality: "many",
+            },
+        ]);
+    });
+
+    it("omits non-FK object-backed links without synthesizing a foreign key", () => {
+        const linkRid = "ri.ontology.main.link-type.author-editor";
+        const result = convertFoundryMetaLinkTypes([
+            objectType({
+                apiName: "Author",
+                linkTypes: [
+                    {
+                        apiName: "editedBy",
+                        displayName: "Edited by",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Author",
+                        cardinality: "ONE",
+                        linkTypeRid: linkRid,
+                    },
+                    {
+                        apiName: "edits",
+                        displayName: "Edits",
+                        status: "ACTIVE",
+                        objectTypeApiName: "Author",
+                        cardinality: "MANY",
+                        linkTypeRid: linkRid,
+                    },
+                ],
+            }),
+        ]);
+
+        expect(result).toEqual([]);
+        expect(result.every((link) => Boolean(link.foreignKey))).toBe(true);
+    });
+});

--- a/packages/ontology/src/ir/validate.ts
+++ b/packages/ontology/src/ir/validate.ts
@@ -688,6 +688,24 @@ export function validate(ontology: OntologyIR): ValidationResult {
                 path: [...ltPath, "target", "objectType"],
             });
         }
+
+        const foreignKeyRoot = lt.foreignKey.split(".")[0]!;
+        const sourceType = ontology.objectTypes.find(
+            (candidate) => candidate.name === lt.source.objectType
+        );
+        const targetType = ontology.objectTypes.find(
+            (candidate) => candidate.name === lt.target.objectType
+        );
+        const sourceHasFk =
+            sourceType?.properties.some((property) => property.name === foreignKeyRoot) ?? false;
+        const targetHasFk =
+            targetType?.properties.some((property) => property.name === foreignKeyRoot) ?? false;
+        if (!sourceHasFk && !targetHasFk) {
+            errors.push({
+                message: `Foreign key "${lt.foreignKey}" does not exist on either side of link "${lt.id}".`,
+                path: [...ltPath, "foreignKey"],
+            });
+        }
     }
 
     const actionNames = new Set<string>();

--- a/packages/ontology/src/live/LiveOntology.test.ts
+++ b/packages/ontology/src/live/LiveOntology.test.ts
@@ -1,7 +1,7 @@
 import { MemoryBlobBytesStore, SingleProcessCoordination } from "@party-stack/runtime";
 import { describe, expect, it, vi } from "vitest";
 import { o } from "../ir/index.js";
-import { createLiveOntology, type OntologyDefinition } from "./LiveOntology.js";
+import { createLiveOntology, waitForLiveOntologyReady, type OntologyDefinition } from "./LiveOntology.js";
 import type { OntologyBackendAdapter } from "./OntologyBackendAdapter.js";
 import type { OntologyIR } from "../ir/index.js";
 
@@ -163,6 +163,134 @@ describe("createLiveOntology", () => {
         }
         await queued;
         expect(applyAction).toHaveBeenCalledTimes(2);
+        await ontology.cleanup();
+        await coordination.close();
+    });
+
+    it("exposes ready and settles immediate cleanup without unhandled rejections", async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => {
+            unhandled.push(reason);
+        };
+        process.on("unhandledRejection", onUnhandled);
+
+        const coordination = new SingleProcessCoordination({
+            scope: "lifecycle-cleanup",
+        });
+        const backendAdapter: OntologyBackendAdapter = {
+            name: "test",
+            getCollectionOptions: () => ({
+                syncMode: "on-demand",
+                sync: {
+                    sync: ({ markReady }) => {
+                        markReady();
+                        return {};
+                    },
+                },
+            }),
+            applyAction: () => Promise.resolve(),
+            runQueryFunction: () => Promise.resolve(undefined),
+        };
+
+        try {
+            const ontology = await createLiveOntology({
+                id: "lifecycle-cleanup",
+                ir: {
+                    ...ir,
+                    objectTypes: [
+                        {
+                            name: "Note",
+                            displayName: "Note",
+                            pluralDisplayName: "Notes",
+                            primaryKey: "id",
+                            properties: [
+                                {
+                                    name: "id",
+                                    displayName: "ID",
+                                    type: o.string({}),
+                                },
+                            ],
+                        },
+                    ],
+                    queryFunctionTypes: [],
+                },
+                backend: () => backendAdapter,
+                runtime: () => ({
+                    owner: "user",
+                    namespace: "lifecycle-cleanup",
+                    blobBytes: new MemoryBlobBytesStore(),
+                    coordination,
+                }),
+            });
+
+            const ready = ontology.ready;
+            await expect(Promise.all([ready, ontology.cleanup()])).resolves.toBeDefined();
+            await expect(ontology.cleanup()).resolves.toBeUndefined();
+            expect(unhandled).toEqual([]);
+        } finally {
+            process.off("unhandledRejection", onUnhandled);
+            await coordination.close();
+        }
+    });
+
+    it("waits for on-demand collections via waitForLiveOntologyReady", async () => {
+        let syncStarted = false;
+        const coordination = new SingleProcessCoordination({
+            scope: "wait-ready",
+        });
+        const backendAdapter: OntologyBackendAdapter = {
+            name: "test",
+            getCollectionOptions: () => ({
+                syncMode: "on-demand",
+                sync: {
+                    sync: ({ markReady }) => {
+                        syncStarted = true;
+                        // Defer ready so waitForCollectionReady must start sync first.
+                        queueMicrotask(() => markReady());
+                        return {
+                            loadSubset: () => true as const,
+                        };
+                    },
+                },
+            }),
+            applyAction: () => Promise.resolve(),
+            runQueryFunction: () => Promise.resolve(undefined),
+        };
+
+        const ontology = await createLiveOntology({
+            id: "wait-ready",
+            ir: {
+                ...ir,
+                objectTypes: [
+                    {
+                        name: "Note",
+                        displayName: "Note",
+                        pluralDisplayName: "Notes",
+                        primaryKey: "id",
+                        properties: [
+                            {
+                                name: "id",
+                                displayName: "ID",
+                                type: o.string({}),
+                            },
+                        ],
+                    },
+                ],
+                queryFunctionTypes: [],
+            },
+            backend: () => backendAdapter,
+            runtime: () => ({
+                owner: "user",
+                namespace: "wait-ready",
+                blobBytes: new MemoryBlobBytesStore(),
+                coordination,
+            }),
+        });
+
+        expect(ontology.objects.Note!.status).toBe("idle");
+        await expect(waitForLiveOntologyReady(ontology)).resolves.toBeUndefined();
+        expect(syncStarted).toBe(true);
+        expect(ontology.objects.Note!.status).toBe("ready");
         await ontology.cleanup();
         await coordination.close();
     });

--- a/packages/ontology/src/live/LiveOntology.ts
+++ b/packages/ontology/src/live/LiveOntology.ts
@@ -9,6 +9,7 @@ import {
 } from "./attachments/createLiveOntologyAttachments.js";
 import { unsupportedOntologyAttachmentsAdapter } from "./attachments/unsupportedOntologyAttachmentsAdapter.js";
 import { createLiveOntologyObjectCollection } from "./objects/createLiveOntologyObjectCollection.js";
+import { waitForCollectionsReady } from "./waitForCollectionReady.js";
 import type { LiveOntologyAction } from "./actions/createLiveOntologyAction.js";
 import type { OntologyMutatorRegistry } from "./mutators/types.js";
 import type { OntologyCollection } from "./objects/createLiveOntologyObjectCollection.js";
@@ -21,6 +22,10 @@ import type { attachment } from "../utils/values.js";
 export type { LiveOntologyAction, LiveOntologyActionOptions } from "./actions/createLiveOntologyAction.js";
 export type { LiveOntologyAttachments } from "./attachments/createLiveOntologyAttachments.js";
 export type { OntologyCollection } from "./objects/createLiveOntologyObjectCollection.js";
+export {
+    waitForCollectionReady,
+    waitForCollectionsReady,
+} from "./waitForCollectionReady.js";
 
 export type LiveOntologyWriteMode = "direct" | "outbox";
 
@@ -82,6 +87,11 @@ export type LiveOntologyQueryFunctions<QueryFunctionTypes extends OntologyDefini
 
 export interface LiveOntology<Ontology extends OntologyDefinition = OntologyDefinition> {
     readonly ir: OntologyIR;
+    /**
+     * Resolves once outbox and blob metadata subsystems have finished starting.
+     * Object collections remain on-demand unless explicitly preloaded.
+     */
+    readonly ready: Promise<void>;
     objects: LiveOntologyObjects<Ontology["objectTypes"]>;
     actions: LiveOntologyActions<Ontology["actionTypes"]>;
     queryFunctions: LiveOntologyQueryFunctions<Ontology["queryFunctionTypes"]>;
@@ -99,6 +109,17 @@ export interface CreateLiveOntologyOpts<Context extends Record<string, unknown> 
     writes?: LiveOntologyWrites;
     context?: Context;
     getUserId?: (context: Context) => string;
+}
+
+/**
+ * Waits for LiveOntology subsystems required before safe use.
+ * Starts on-demand object collection sync via preload without loading subsets.
+ */
+export async function waitForLiveOntologyReady(ontology: LiveOntology): Promise<void> {
+    await ontology.ready;
+    await waitForCollectionsReady(
+        Object.values(ontology.objects) as Collection<Record<string, unknown>, string | number>[]
+    );
 }
 
 export async function createLiveOntology<
@@ -163,9 +184,14 @@ export async function createLiveOntology<
                 }),
         ])
     );
+    const ready = Promise.all([actionsSubsystem.outbox.ready, blobManager.ready]).then(() => undefined);
+    void ready.catch(() => undefined);
+
+    let cleanupPromise: Promise<void> | undefined;
 
     return {
         ir: opts.ir,
+        ready,
         objects: objects as unknown as LiveOntologyObjects<Ontology["objectTypes"]>,
         actions: actionsSubsystem.actions as unknown as LiveOntologyActions<Ontology["actionTypes"]>,
         queryFunctions: queryFunctions as unknown as LiveOntologyQueryFunctions<
@@ -174,11 +200,30 @@ export async function createLiveOntology<
         attachments,
         outbox: actionsSubsystem.outbox,
         cleanup: async () => {
-            await actionsSubsystem.outbox.cleanup();
-            await Promise.all(Object.values(objects).map((collection) => collection.cleanup()));
-            await blobManager.cleanup();
-            await backendAdapter.cleanup?.();
-            await runtime.cleanup?.();
+            cleanupPromise ??= (async () => {
+                // Settle subsystem startups before tearing down persistence.
+                await Promise.allSettled([ready]);
+                await actionsSubsystem.outbox.cleanup();
+                await Promise.all(
+                    Object.values(objects).map(async (collection) => {
+                        const status = collection.status;
+                        if (status === "cleaned-up") return;
+                        // Settle in-flight startup only; ready/idle need no preload.
+                        if (status === "loading") {
+                            await Promise.allSettled([collection.preload()]);
+                        }
+                        try {
+                            await collection.cleanup();
+                        } catch {
+                            // Idempotent: already cleaned up during preload race.
+                        }
+                    })
+                );
+                await blobManager.cleanup();
+                await backendAdapter.cleanup?.();
+                await runtime.cleanup?.();
+            })();
+            return cleanupPromise;
         },
     };
 }

--- a/packages/ontology/src/live/OntologyBackendAdapter.ts
+++ b/packages/ontology/src/live/OntologyBackendAdapter.ts
@@ -21,7 +21,34 @@ export interface OntologyAttachmentIdMapping {
 
 export interface OntologyApplyActionResult {
     attachmentIdMappings?: OntologyAttachmentIdMapping[];
+    /**
+     * Object types that may have changed as a result of the action.
+     * When omitted, clients may fall back to refreshing all known object types.
+     */
+    invalidatedObjectTypes?: string[];
 }
+
+export interface OntologyActionRefreshResult {
+    status: "ok" | "error" | "aborted";
+    objectType: string;
+    error?: {
+        name: string;
+        message: string;
+    };
+}
+
+export interface OntologyActionRefreshDiagnostics {
+    /**
+     * Best-effort cache refresh after a confirmed write.
+     * Never rejects; failures are reported in the resolved results.
+     */
+    completed: Promise<OntologyActionRefreshResult[]>;
+}
+
+export interface OntologyApplyActionClientResult extends OntologyApplyActionResult {
+    refresh?: OntologyActionRefreshDiagnostics;
+}
+
 
 export interface ApplyActionLiveOpts {
     objects: Record<string, Collection<Record<string, unknown>>>;

--- a/packages/ontology/src/live/index.ts
+++ b/packages/ontology/src/live/index.ts
@@ -7,3 +7,7 @@ export type {
 export * from "./mutators/types.js";
 export * from "./mutators/runOptimisticAction.js";
 export * from "./outbox/types.js";
+export {
+    waitForCollectionReady,
+    waitForCollectionsReady,
+} from "./waitForCollectionReady.js";

--- a/packages/ontology/src/live/outbox/createOntologyOutbox.ts
+++ b/packages/ontology/src/live/outbox/createOntologyOutbox.ts
@@ -372,6 +372,9 @@ export function createOntologyOutbox(options: CreateOntologyOutboxOptions): Star
     const collection = createOutboxCollection(options);
     let outbox: OntologyOutbox | undefined;
     const ready = deferred<void>();
+    // Prevent unhandled rejection when cleanup races startup.
+    void ready.promise.catch(() => undefined);
+    let cleanupPromise: Promise<void> | undefined;
     const task = run(function* () {
         try {
             const value = yield* useOntologyOutbox(options, collection);
@@ -406,7 +409,16 @@ export function createOntologyOutbox(options: CreateOntologyOutboxOptions): Star
             return outbox!.retry(id);
         },
         async cleanup() {
-            await task.halt();
+            cleanupPromise ??= (async () => {
+                // Let persistence startup settle before tearing down so
+                // loopback markReady cannot race cleaned-up status.
+                await Promise.allSettled([ready.promise, collection.preload()]);
+                await task.halt().catch(() => undefined);
+                if (collection.status !== "cleaned-up") {
+                    await collection.cleanup().catch(() => undefined);
+                }
+            })();
+            return cleanupPromise;
         },
     };
 }

--- a/packages/ontology/src/live/waitForCollectionReady.ts
+++ b/packages/ontology/src/live/waitForCollectionReady.ts
@@ -1,0 +1,70 @@
+import type { Collection } from "@tanstack/db";
+
+/**
+ * Starts idle/on-demand collection synchronization through the public
+ * `startSyncImmediate()` API and waits until the collection is ready.
+ *
+ * This initializes synchronization without eagerly loading every object subset.
+ * Foundry on-demand collections mark ready as soon as their sync loop starts;
+ * subset loads still happen only when queries request them.
+ *
+ * Race-safe: status listeners are registered before starting sync / reading
+ * the current status, so a transition cannot be missed.
+ */
+export async function waitForCollectionReady(
+    collection: Collection<Record<string, unknown>, string | number>
+): Promise<void> {
+    if (collection.status === "ready") return;
+    if (collection.status === "error") {
+        throw new Error(`Collection "${collection.id}" is in an error state.`);
+    }
+    if (collection.status === "cleaned-up") {
+        throw new Error(`Collection "${collection.id}" has been cleaned up.`);
+    }
+
+    await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const finish = (error?: Error) => {
+            if (settled) return;
+            settled = true;
+            off();
+            if (error) reject(error);
+            else resolve();
+        };
+
+        const off = collection.on("status:change", (event) => {
+            if (event.status === "ready") {
+                finish();
+            } else if (event.status === "error") {
+                finish(new Error(`Collection "${collection.id}" is in an error state.`));
+            } else if (event.status === "cleaned-up") {
+                finish(new Error(`Collection "${collection.id}" has been cleaned up.`));
+            }
+        });
+
+        // Start sync after the listener is attached so we cannot miss ready.
+        if (collection.status === "idle") {
+            try {
+                collection.startSyncImmediate();
+            } catch (error) {
+                finish(error instanceof Error ? error : new Error(String(error)));
+                return;
+            }
+        }
+
+        // Close the TOCTOU window for a status that was already terminal.
+        if (collection.status === "ready") {
+            finish();
+        } else if (collection.status === "error") {
+            finish(new Error(`Collection "${collection.id}" is in an error state.`));
+        } else if (collection.status === "cleaned-up") {
+            finish(new Error(`Collection "${collection.id}" has been cleaned up.`));
+        }
+    });
+}
+
+export async function waitForCollectionsReady(
+    collections: Iterable<Collection<Record<string, unknown>, string | number>>
+): Promise<void> {
+    await Promise.all([...collections].map((collection) => waitForCollectionReady(collection)));
+}

--- a/packages/remote-ontology/README.md
+++ b/packages/remote-ontology/README.md
@@ -1,0 +1,16 @@
+# @party-stack/remote-ontology
+
+HTTP remoting for LiveOntology with policy-aware describe/load/apply and structured errors.
+
+## Describe projection
+
+`projectRemoteOntologyIR` supports:
+
+- `projectionMode: "legacy"` — historical behavior (full object/link schema; action fixed-parameter projection)
+- `projectionMode: "authorized"` — project object types/properties, prune broken links, hide actions/queries that reference hidden types, and drop unreachable named types
+
+When `allowedObjectTypeProperties` or `baseObjectTypeQueries` is configured, describe defaults to `authorized`.
+
+## Errors
+
+Error responses use versioned envelopes (`v: 1`) with stable codes. Legacy `{ error: string }` bodies remain parseable by clients.

--- a/packages/remote-ontology/src/client.test.ts
+++ b/packages/remote-ontology/src/client.test.ts
@@ -1,12 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Temporal } from "temporal-polyfill";
-import { o, type OntologyIR } from "@party-stack/ontology";
-import { createRemoteLiveOntology } from "./client.js";
+import { o, type OntologyIR, type OntologyApplyActionClientResult } from "@party-stack/ontology";
+import {
+    createRemoteLiveOntology,
+    createRemoteOntologyBackendAdapter,
+} from "./client.js";
 import type { RemoteOntologyTransport } from "./protocol.js";
 
 const ir: OntologyIR = {
     types: [],
-    objectTypes: [],
+    objectTypes: [
+        {
+            name: "Note",
+            displayName: "Note",
+            pluralDisplayName: "Notes",
+            primaryKey: "id",
+            properties: [{ name: "id", displayName: "ID", type: o.string({}) }],
+        },
+    ],
     linkTypes: [],
     actionTypes: [
         {
@@ -75,5 +86,74 @@ describe("createRemoteLiveOntology", () => {
             dueDate: Temporal.PlainDate.from("2026-06-15"),
         });
         await expect(ontology.queryFunctions.greet!({ name: "Alice" })).resolves.toBe("Hello Alice");
+        await ontology.cleanup();
+    });
+});
+
+describe("createRemoteOntologyBackendAdapter.applyAction", () => {
+    it("resolves successful writes even when subsequent refetches reject or abort", async () => {
+        const transport: RemoteOntologyTransport = {
+            describe: async () => ({ ir }),
+            loadSubset: async (request) => ({
+                objectType: request.objectType,
+                objects: [],
+            }),
+            applyAction: async () => ({
+                invalidatedObjectTypes: ["Note"],
+                attachmentIdMappings: [{ localId: "local", remoteId: "remote" }],
+            }),
+            runQueryFunction: async () => ({ value: undefined }),
+            getAttachmentMetadata: async () => ({}),
+            getAttachmentContent: async () => new Blob(),
+        };
+        const adapter = createRemoteOntologyBackendAdapter({ ir, transport });
+        const abortError = new DOMException("The operation was aborted.", "AbortError");
+        const refetch = vi
+            .fn()
+            .mockRejectedValueOnce(abortError)
+            .mockRejectedValueOnce(new Error("network failed"));
+
+        const first = (await adapter.applyAction(
+            "createNote",
+            { title: "one" },
+            {
+                objects: {
+                    Note: {
+                        utils: { refetch },
+                    } as never,
+                },
+            }
+        )) as OntologyApplyActionClientResult;
+
+        expect(first.attachmentIdMappings).toEqual([{ localId: "local", remoteId: "remote" }]);
+        expect(first.invalidatedObjectTypes).toEqual(["Note"]);
+        await expect(first.refresh!.completed).resolves.toEqual([
+            {
+                status: "aborted",
+                objectType: "Note",
+                error: { name: "AbortError", message: "The operation was aborted." },
+            },
+        ]);
+
+        const second = (await adapter.applyAction(
+            "createNote",
+            { title: "two" },
+            {
+                objects: {
+                    Note: {
+                        utils: { refetch },
+                    } as never,
+                },
+            }
+        )) as OntologyApplyActionClientResult;
+
+        await expect(second.refresh!.completed).resolves.toEqual([
+            {
+                status: "error",
+                objectType: "Note",
+                error: { name: "Error", message: "network failed" },
+            },
+        ]);
+        expect(refetch).toHaveBeenCalledTimes(2);
     });
 });

--- a/packages/remote-ontology/src/client.ts
+++ b/packages/remote-ontology/src/client.ts
@@ -11,6 +11,8 @@ import type {
     OntologyBackendAdapterProvider,
     OntologyCollectionOptions,
     OntologyIR,
+    OntologyActionRefreshResult,
+    OntologyApplyActionClientResult,
 } from "@party-stack/ontology";
 import { serializeLoadSubsetOptions, type RemoteOntologyTransport } from "./protocol.js";
 
@@ -49,6 +51,55 @@ function getObjectTypePrimaryKey(ir: OntologyIR, objectType: string): string {
         throw new Error(`Unknown ontology object type "${objectType}".`);
     }
     return objectTypeDef.primaryKey;
+}
+
+function toRefreshError(error: unknown): OntologyActionRefreshResult["error"] {
+    if (error instanceof Error) {
+        return { name: error.name, message: error.message };
+    }
+    return { name: "Error", message: String(error) };
+}
+
+function isAbortError(error: unknown): boolean {
+    return (
+        (error instanceof Error && error.name === "AbortError") ||
+        (typeof DOMException !== "undefined" &&
+            error instanceof DOMException &&
+            error.name === "AbortError")
+    );
+}
+
+async function refreshInvalidatedCollections(opts: {
+    objectTypes: string[];
+    objects: Record<string, Collection<Record<string, unknown>>>;
+}): Promise<OntologyActionRefreshResult[]> {
+    return Promise.all(
+        opts.objectTypes.map(async (objectType): Promise<OntologyActionRefreshResult> => {
+            const collection = opts.objects[objectType] as
+                | Collection<Record<string, unknown>, string | number, QueryCollectionUtils<Record<string, unknown>>>
+                | undefined;
+            if (!collection?.utils?.refetch) {
+                return { status: "ok", objectType };
+            }
+            try {
+                await collection.utils.refetch({ throwOnError: true });
+                return { status: "ok", objectType };
+            } catch (error) {
+                if (isAbortError(error)) {
+                    return {
+                        status: "aborted",
+                        objectType,
+                        error: toRefreshError(error),
+                    };
+                }
+                return {
+                    status: "error",
+                    objectType,
+                    error: toRefreshError(error),
+                };
+            }
+        })
+    );
 }
 
 export function createRemoteOntologyBackendAdapter(
@@ -97,19 +148,23 @@ export function createRemoteOntologyBackendAdapter(
                     ? response.invalidatedObjectTypes
                     : opts.ir.objectTypes.map((objectType) => objectType.name);
 
-            await Promise.all(
-                invalidatedObjectTypes.map((objectType) => {
-                    const collection = live.objects[objectType] as Collection<
-                        Record<string, unknown>,
-                        string | number,
-                        QueryCollectionUtils<Record<string, unknown>>
-                    >;
-                    return collection.utils.refetch({ throwOnError: true });
-                })
-            );
-            return {
+            // Confirmed writes remain successful even when cache refresh fails
+            // or is aborted by navigation. Refresh is best-effort and observable.
+            const refreshCompleted = refreshInvalidatedCollections({
+                objectTypes: invalidatedObjectTypes,
+                objects: live.objects,
+            });
+            // Prevent unhandled rejections if callers never await diagnostics.
+            void refreshCompleted.catch(() => undefined);
+
+            const result: OntologyApplyActionClientResult = {
                 attachmentIdMappings: response.attachmentIdMappings,
+                invalidatedObjectTypes,
+                refresh: {
+                    completed: refreshCompleted,
+                },
             };
+            return result;
         },
         runQueryFunction: async (queryFunctionType, parameters) => {
             const response = await transport.runQueryFunction({

--- a/packages/remote-ontology/src/errors.test.ts
+++ b/packages/remote-ontology/src/errors.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest";
+import {
+    parseRemoteOntologyErrorBody,
+    RemoteOntologyError,
+    remoteOntologyErrorFromUnknown,
+} from "./errors.js";
+import { createHttpRemoteOntologyTransport } from "./http.js";
+import { createRemoteOntologyServer } from "./server.js";
+import { serializeRemoteOntologyJson } from "./protocol.js";
+import { o, type OntologyBackendAdapter, type OntologyIR } from "@party-stack/ontology";
+
+const ir: OntologyIR = {
+    types: [],
+    objectTypes: [],
+    linkTypes: [],
+    actionTypes: [
+        {
+            name: "createNote",
+            displayName: "Create note",
+            parameters: [{ name: "title", displayName: "Title", type: o.string({}) }],
+            logic: [],
+        },
+    ],
+    queryFunctionTypes: [],
+};
+
+const backendAdapter: OntologyBackendAdapter = {
+    name: "test",
+    getCollectionOptions: () => ({
+        syncMode: "eager",
+        sync: {
+            sync: ({ markReady }) => {
+                markReady();
+            },
+        },
+    }),
+    applyAction: async () => {},
+    runQueryFunction: async () => undefined,
+};
+
+describe("remote ontology error protocol", () => {
+    it("round-trips structured 400/403/404/validation/500 errors over HTTP", async () => {
+        const cases = [
+            {
+                status: 400,
+                envelope: {
+                    v: 1 as const,
+                    name: "ZodError",
+                    code: "BAD_REQUEST" as const,
+                    status: 400,
+                    message: "Invalid request",
+                    retryable: false,
+                },
+            },
+            {
+                status: 403,
+                envelope: {
+                    v: 1 as const,
+                    name: "RemoteOntologyForbiddenError",
+                    code: "FORBIDDEN" as const,
+                    status: 403,
+                    message: "Action denied",
+                    retryable: false,
+                },
+            },
+            {
+                status: 404,
+                envelope: {
+                    v: 1 as const,
+                    name: "NonRetryableError",
+                    code: "NOT_FOUND" as const,
+                    status: 404,
+                    message: "Missing object",
+                    retryable: false,
+                },
+            },
+            {
+                status: 400,
+                envelope: {
+                    v: 1 as const,
+                    name: "NonRetryableError",
+                    code: "VALIDATION" as const,
+                    status: 400,
+                    message: "Invalid Action arguments.",
+                    retryable: false,
+                    details: { parameters: { title: "required" } },
+                },
+            },
+            {
+                status: 500,
+                envelope: {
+                    v: 1 as const,
+                    name: "Error",
+                    code: "INTERNAL" as const,
+                    status: 500,
+                    message: "boom",
+                    retryable: true,
+                },
+            },
+        ];
+
+        for (const testCase of cases) {
+            const transport = createHttpRemoteOntologyTransport({
+                url: "https://example.test/remote/",
+                ir,
+                fetch: async () =>
+                    new Response(JSON.stringify(testCase.envelope), {
+                        status: testCase.status,
+                        headers: { "content-type": "application/json" },
+                    }),
+            });
+
+            await expect(transport.applyAction({ actionType: "createNote", parameters: {} })).rejects.toMatchObject(
+                {
+                    name: testCase.envelope.name,
+                    code: testCase.envelope.code,
+                    status: testCase.envelope.status,
+                    message: testCase.envelope.message,
+                    retryable: testCase.envelope.retryable,
+                }
+            );
+        }
+    });
+
+    it("parses legacy { error } bodies and serializes forbidden responses from the server", async () => {
+        const legacy = parseRemoteOntologyErrorBody(JSON.stringify({ error: "nope" }), 403);
+        expect(legacy).toBeInstanceOf(RemoteOntologyError);
+        expect(legacy).toMatchObject({
+            code: "FORBIDDEN",
+            status: 403,
+            message: "nope",
+            retryable: false,
+        });
+
+        const server = createRemoteOntologyServer({
+            ir,
+            backendAdapter,
+            policy: {
+                canApplyAction: () => false,
+            },
+        });
+        const response = await server.handleRequest(
+            new Request("http://example.test/apply-action", {
+                method: "POST",
+                body: serializeRemoteOntologyJson({
+                    actionType: "createNote",
+                    parameters: { title: "x" },
+                }),
+            })
+        );
+        expect(response.status).toBe(403);
+        const body = JSON.parse(await response.text());
+        expect(body).toMatchObject({
+            v: 1,
+            code: "FORBIDDEN",
+            status: 403,
+            retryable: false,
+            message: 'Action "createNote" is not allowed.',
+        });
+        expect(RemoteOntologyError.fromEnvelope(body).toJSON()).toEqual(body);
+
+        const methodResponse = await server.handleRequest(
+            new Request("http://example.test/describe"),
+        );
+        expect(methodResponse.status).toBe(405);
+        await expect(
+            methodResponse.json(),
+        ).resolves.toMatchObject({
+            code: "BAD_REQUEST",
+            status: 405,
+            retryable: false,
+        });
+    });
+
+    it("maps unknown failures to sanitized internal errors", () => {
+        const error = remoteOntologyErrorFromUnknown(new Error("secret stack details"));
+        expect(error).toMatchObject({
+            code: "INTERNAL",
+            status: 500,
+            retryable: true,
+            message: "secret stack details",
+        });
+    });
+});

--- a/packages/remote-ontology/src/errors.ts
+++ b/packages/remote-ontology/src/errors.ts
@@ -1,0 +1,219 @@
+import { z } from "zod";
+
+export type RemoteOntologyErrorCode =
+    | "FORBIDDEN"
+    | "VALIDATION"
+    | "NOT_FOUND"
+    | "BAD_REQUEST"
+    | "BACKEND"
+    | "INTERNAL";
+
+export interface RemoteOntologyErrorDetails {
+    parameters?: Record<string, unknown>;
+    validation?: unknown;
+    [key: string]: unknown;
+}
+
+export interface RemoteOntologyErrorEnvelope {
+    v: 1;
+    name: string;
+    code: RemoteOntologyErrorCode;
+    status: number;
+    message: string;
+    retryable: boolean;
+    details?: RemoteOntologyErrorDetails;
+}
+
+export const remoteOntologyErrorEnvelopeSchema = z
+    .object({
+        v: z.literal(1),
+        name: z.string().min(1),
+        code: z.enum(["FORBIDDEN", "VALIDATION", "NOT_FOUND", "BAD_REQUEST", "BACKEND", "INTERNAL"]),
+        status: z.number().int().positive(),
+        message: z.string(),
+        retryable: z.boolean(),
+        details: z.record(z.string(), z.unknown()).optional(),
+    })
+    .strict() satisfies z.ZodType<RemoteOntologyErrorEnvelope>;
+
+export class RemoteOntologyError extends Error {
+    readonly code: RemoteOntologyErrorCode;
+    readonly status: number;
+    readonly retryable: boolean;
+    readonly details?: RemoteOntologyErrorDetails;
+
+    constructor(opts: {
+        name?: string;
+        code: RemoteOntologyErrorCode;
+        status: number;
+        message: string;
+        retryable?: boolean;
+        details?: RemoteOntologyErrorDetails;
+        cause?: unknown;
+    }) {
+        super(opts.message, opts.cause !== undefined ? { cause: opts.cause } : undefined);
+        this.name = opts.name ?? "RemoteOntologyError";
+        this.code = opts.code;
+        this.status = opts.status;
+        this.retryable = opts.retryable ?? defaultRetryable(opts.code, opts.status);
+        this.details = opts.details;
+    }
+
+    toJSON(): RemoteOntologyErrorEnvelope {
+        return {
+            v: 1,
+            name: this.name,
+            code: this.code,
+            status: this.status,
+            message: this.message,
+            retryable: this.retryable,
+            ...(this.details ? { details: this.details } : {}),
+        };
+    }
+
+    static fromEnvelope(envelope: RemoteOntologyErrorEnvelope): RemoteOntologyError {
+        return new RemoteOntologyError({
+            name: envelope.name,
+            code: envelope.code,
+            status: envelope.status,
+            message: envelope.message,
+            retryable: envelope.retryable,
+            details: envelope.details,
+        });
+    }
+}
+
+function defaultRetryable(code: RemoteOntologyErrorCode, status: number): boolean {
+    if (code === "FORBIDDEN" || code === "VALIDATION" || code === "NOT_FOUND" || code === "BAD_REQUEST") {
+        return false;
+    }
+    return status >= 500;
+}
+
+export function isRemoteOntologyErrorEnvelope(value: unknown): value is RemoteOntologyErrorEnvelope {
+    return remoteOntologyErrorEnvelopeSchema.safeParse(value).success;
+}
+
+export function parseRemoteOntologyErrorBody(
+    text: string,
+    status: number
+): RemoteOntologyError {
+    if (!text) {
+        return new RemoteOntologyError({
+            code: statusToCode(status),
+            status,
+            message: `Remote ontology request failed with status ${status}.`,
+        });
+    }
+
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (isRemoteOntologyErrorEnvelope(parsed)) {
+            return RemoteOntologyError.fromEnvelope(parsed);
+        }
+        if (
+            typeof parsed === "object" &&
+            parsed !== null &&
+            "error" in parsed &&
+            typeof (parsed as { error: unknown }).error === "string"
+        ) {
+            // Legacy `{ error: string }` compatibility.
+            return new RemoteOntologyError({
+                code: statusToCode(status),
+                status,
+                message: (parsed as { error: string }).error,
+            });
+        }
+    } catch {
+        // Fall through to raw text.
+    }
+
+    return new RemoteOntologyError({
+        code: statusToCode(status),
+        status,
+        message: text,
+    });
+}
+
+export function statusToCode(status: number): RemoteOntologyErrorCode {
+    if (status === 403) return "FORBIDDEN";
+    if (status === 404) return "NOT_FOUND";
+    if (status === 422) return "VALIDATION";
+    if (status >= 400 && status < 500) {
+        return "BAD_REQUEST";
+    }
+    if (status >= 500) return "INTERNAL";
+    return "BACKEND";
+}
+
+export function remoteOntologyErrorFromUnknown(error: unknown): RemoteOntologyError {
+    if (error instanceof RemoteOntologyError) return error;
+
+    if (error instanceof Error && error.name === "RemoteOntologyForbiddenError") {
+        return new RemoteOntologyError({
+            name: "RemoteOntologyForbiddenError",
+            code: "FORBIDDEN",
+            status: 403,
+            message: error.message,
+            retryable: false,
+        });
+    }
+
+    if (error instanceof Error && error.name === "ZodError") {
+        return new RemoteOntologyError({
+            name: "ZodError",
+            code: "BAD_REQUEST",
+            status: 400,
+            message: error.message,
+            retryable: false,
+            details: {
+                validation: "issues" in error ? (error as { issues: unknown }).issues : undefined,
+            },
+        });
+    }
+
+    if (error instanceof Error && error.name === "NonRetryableError") {
+        const message = error.message.toLowerCase();
+        if (message.includes("not found")) {
+            return new RemoteOntologyError({
+                name: error.name,
+                code: "NOT_FOUND",
+                status: 404,
+                message: error.message,
+                retryable: false,
+                cause: error,
+            });
+        }
+        if (message.includes("invalid")) {
+            return new RemoteOntologyError({
+                name: error.name,
+                code: "VALIDATION",
+                status: 400,
+                message: error.message,
+                retryable: false,
+                cause: error,
+            });
+        }
+        return new RemoteOntologyError({
+            name: error.name,
+            code: "BACKEND",
+            status: 400,
+            message: error.message,
+            retryable: false,
+            cause: error,
+        });
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    // Sanitize potential sensitive backend details from unexpected failures.
+    const safeMessage =
+        message.length > 500 ? "Remote ontology request failed." : message || "Remote ontology request failed.";
+    return new RemoteOntologyError({
+        name: error instanceof Error ? error.name : "RemoteOntologyError",
+        code: "INTERNAL",
+        status: 500,
+        message: safeMessage,
+        retryable: true,
+        cause: error,
+    });
+}

--- a/packages/remote-ontology/src/http.ts
+++ b/packages/remote-ontology/src/http.ts
@@ -10,6 +10,7 @@ import type {
 } from "./protocol.js";
 import type { OntologyIR, PartialAttachmentMetadata } from "@party-stack/ontology";
 import { decode, encode } from "@party-stack/ontology/json";
+import { parseRemoteOntologyErrorBody } from "./errors.js";
 import { parseRemoteOntologyJson, serializeRemoteOntologyJson } from "./protocol.js";
 
 export interface HttpRemoteOntologyTransportOptions {
@@ -26,6 +27,12 @@ function resolveEndpoint(baseUrl: string | URL, path: string): string {
         return new URL(path, normalizedBase).toString();
     }
     return `${normalizedBase}${path}`;
+}
+
+async function throwIfNotOk(response: Response): Promise<void> {
+    if (response.ok) return;
+    const message = await response.text();
+    throw parseRemoteOntologyErrorBody(message, response.status);
 }
 
 async function postJson<TResponse>(
@@ -45,11 +52,7 @@ async function postJson<TResponse>(
         signal: options?.signal,
     });
 
-    if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || `Remote ontology request failed with status ${response.status}.`);
-    }
-
+    await throwIfNotOk(response);
     return parseRemoteOntologyJson(await response.text()) as TResponse;
 }
 
@@ -79,11 +82,7 @@ async function postMultipart<TResponse>(
         signal: options?.signal,
     });
 
-    if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || `Remote ontology request failed with status ${response.status}.`);
-    }
-
+    await throwIfNotOk(response);
     return parseRemoteOntologyJson(await response.text()) as TResponse;
 }
 
@@ -104,11 +103,7 @@ async function postBlob(
         signal: options?.signal,
     });
 
-    if (!response.ok) {
-        const message = await response.text();
-        throw new Error(message || `Remote ontology request failed with status ${response.status}.`);
-    }
-
+    await throwIfNotOk(response);
     return response.blob();
 }
 

--- a/packages/remote-ontology/src/index.ts
+++ b/packages/remote-ontology/src/index.ts
@@ -1,1 +1,13 @@
 export type { RemoteOntologyTransport } from "./protocol.js";
+export {
+    RemoteOntologyError,
+    parseRemoteOntologyErrorBody,
+    remoteOntologyErrorFromUnknown,
+    isRemoteOntologyErrorEnvelope,
+    remoteOntologyErrorEnvelopeSchema,
+} from "./errors.js";
+export type {
+    RemoteOntologyErrorCode,
+    RemoteOntologyErrorDetails,
+    RemoteOntologyErrorEnvelope,
+} from "./errors.js";

--- a/packages/remote-ontology/src/securedOntology.test.ts
+++ b/packages/remote-ontology/src/securedOntology.test.ts
@@ -98,6 +98,7 @@ describe("secured ontology projection", () => {
 
         const action = projected.actionTypes[0]!;
         expect(action.parameters.map((parameter) => parameter.name)).toEqual(["id", "title"]);
+        expect(projected.objectTypes).toHaveLength(1);
         const step = action.logic[0]!;
         expect(step.kind).toBe("createObject");
         if (step.kind !== "createObject") return;
@@ -116,6 +117,93 @@ describe("secured ontology projection", () => {
                 value: o.Expression.functionCall(o.FunctionCallExpression.now({})),
             },
         ]);
+    });
+
+    it("projects authorized object/property/link visibility and prunes unreachable types", () => {
+        const projected = projectRemoteOntologyIR({
+            ir: {
+                ...ir,
+                types: [
+                    {
+                        name: "SecretStruct",
+                        type: o.struct({
+                            fields: [{ name: "token", displayName: "Token", type: o.string({}) }],
+                        }),
+                    },
+                    {
+                        name: "VisibleStruct",
+                        type: o.struct({
+                            fields: [{ name: "label", displayName: "Label", type: o.string({}) }],
+                        }),
+                    },
+                ],
+                objectTypes: [
+                    ...ir.objectTypes,
+                    {
+                        name: "Hidden",
+                        displayName: "Hidden",
+                        pluralDisplayName: "Hidden",
+                        primaryKey: "id",
+                        properties: [
+                            { name: "id", displayName: "ID", type: o.string({}) },
+                            { name: "secret", displayName: "Secret", type: o.ref({ name: "SecretStruct" }) },
+                        ],
+                    },
+                ],
+                linkTypes: [
+                    {
+                        id: "note-hidden",
+                        source: {
+                            objectType: "Note",
+                            name: "notes",
+                            displayName: "Notes",
+                        },
+                        target: {
+                            objectType: "Hidden",
+                            name: "hidden",
+                            displayName: "Hidden",
+                        },
+                        foreignKey: "id",
+                        cardinality: "one",
+                    },
+                ],
+            },
+            serverContext: {},
+            projectionMode: "authorized",
+            allowedObjectTypeProperties: {
+                Note: ["id", "title", "ownerEmail"],
+            },
+            visibleQueryFunctionTypes: ["publicSearch"],
+        });
+
+        expect(projected.objectTypes.map((objectType) => objectType.name)).toEqual(["Note"]);
+        expect(projected.objectTypes[0]?.properties.map((property) => property.name)).toEqual([
+            "id",
+            "title",
+            "ownerEmail",
+        ]);
+        expect(projected.linkTypes).toEqual([]);
+        expect(projected.queryFunctionTypes.map((query) => query.name)).toEqual(["publicSearch"]);
+        expect(projected.types.map((type) => type.name)).toEqual([]);
+    });
+
+    it("retains explicitly visible write-only actions without leaking hidden logic targets", () => {
+        const projected = projectRemoteOntologyIR({
+            ir,
+            serverContext: {},
+            projectionMode: "authorized",
+            allowedObjectTypeProperties: {},
+            visibleActionTypes: ["createNote"],
+            visibleQueryFunctionTypes: [],
+        });
+
+        expect(projected.objectTypes).toEqual([]);
+        expect(
+            projected.actionTypes.map(
+                (action) => action.name,
+            ),
+        ).toEqual(["createNote"]);
+        expect(projected.actionTypes[0]?.logic).toEqual([]);
     });
 
     it("preserves context references exposed in client context", () => {

--- a/packages/remote-ontology/src/securedOntology.ts
+++ b/packages/remote-ontology/src/securedOntology.ts
@@ -285,6 +285,103 @@ function projectLogicStep<Context>(opts: {
     }
 }
 
+export type RemoteOntologySchemaProjectionMode = "legacy" | "authorized";
+
+function typeReferencesObjectTypes(type: TypeDef, ir: OntologyIR, seen = new Set<string>()): Set<string> {
+    if (type.kind === "ref") {
+        if (seen.has(type.value.name)) return new Set();
+        seen.add(type.value.name);
+        const named = ir.types.find((candidate) => candidate.name === type.value.name);
+        return named ? typeReferencesObjectTypes(named.type, ir, seen) : new Set();
+    }
+    switch (type.kind) {
+        case "objectReference":
+            return new Set([type.value.objectType]);
+        case "optional":
+            return typeReferencesObjectTypes(type.value.type, ir, seen);
+        case "list":
+            return typeReferencesObjectTypes(type.value.elementType, ir, seen);
+        case "map": {
+            const names = typeReferencesObjectTypes(type.value.keyType, ir, seen);
+            for (const name of typeReferencesObjectTypes(type.value.valueType, ir, seen)) names.add(name);
+            return names;
+        }
+        case "result": {
+            const names = typeReferencesObjectTypes(type.value.okType, ir, seen);
+            for (const name of typeReferencesObjectTypes(type.value.errType, ir, seen)) names.add(name);
+            return names;
+        }
+        case "struct": {
+            const names = new Set<string>();
+            for (const field of type.value.fields) {
+                for (const name of typeReferencesObjectTypes(field.type, ir, seen)) names.add(name);
+            }
+            return names;
+        }
+        case "union": {
+            const names = new Set<string>();
+            for (const variant of type.value.variants) {
+                for (const name of typeReferencesObjectTypes(variant.type, ir, seen)) names.add(name);
+            }
+            return names;
+        }
+        default:
+            return new Set();
+    }
+}
+
+function collectReferencedNamedTypes(type: TypeDef, ir: OntologyIR, into: Set<string>, seen = new Set<string>()): void {
+    if (type.kind === "ref") {
+        if (seen.has(type.value.name)) return;
+        seen.add(type.value.name);
+        into.add(type.value.name);
+        const named = ir.types.find((candidate) => candidate.name === type.value.name);
+        if (named) collectReferencedNamedTypes(named.type, ir, into, seen);
+        return;
+    }
+    switch (type.kind) {
+        case "optional":
+            collectReferencedNamedTypes(type.value.type, ir, into, seen);
+            break;
+        case "list":
+            collectReferencedNamedTypes(type.value.elementType, ir, into, seen);
+            break;
+        case "map":
+            collectReferencedNamedTypes(type.value.keyType, ir, into, seen);
+            collectReferencedNamedTypes(type.value.valueType, ir, into, seen);
+            break;
+        case "result":
+            collectReferencedNamedTypes(type.value.okType, ir, into, seen);
+            collectReferencedNamedTypes(type.value.errType, ir, into, seen);
+            break;
+        case "struct":
+            for (const field of type.value.fields) {
+                collectReferencedNamedTypes(field.type, ir, into, seen);
+            }
+            break;
+        case "union":
+            for (const variant of type.value.variants) {
+                collectReferencedNamedTypes(variant.type, ir, into, seen);
+            }
+            break;
+        default:
+            break;
+    }
+}
+
+function actionParametersReferenceHiddenObjectType(
+    actionType: ActionTypeDef,
+    ir: OntologyIR,
+    visibleObjectTypes: Set<string>
+): boolean {
+    for (const parameter of actionType.parameters) {
+        for (const objectType of typeReferencesObjectTypes(parameter.type, ir)) {
+            if (!visibleObjectTypes.has(objectType)) return true;
+        }
+    }
+    return false;
+}
+
 export function projectRemoteOntologyIR<
     Context,
     Ontology extends OntologyDefinition = OntologyDefinition,
@@ -295,10 +392,72 @@ export function projectRemoteOntologyIR<
     clientContextMode?: ClientContextProjectionMode;
     fixedActionParameterValues?: FixedActionParameterValues<Ontology>;
     allowedObjectTypeProperties: Record<string, readonly string[]>;
+    /**
+     * `authorized` projects object/property/link/action/query visibility.
+     * `legacy` keeps historical behavior (full object/link schema; action fixed-param projection only).
+     */
+    projectionMode?: RemoteOntologySchemaProjectionMode;
+    visibleActionTypes?: readonly string[] | "all";
+    visibleQueryFunctionTypes?: readonly string[] | "all";
 }): OntologyIR {
-    return {
-        ...opts.ir,
-        actionTypes: opts.ir.actionTypes.map((actionType) => {
+    const projectionMode = opts.projectionMode ?? "legacy";
+    const visibleObjectTypes = new Set(
+        projectionMode === "authorized"
+            ? Object.entries(opts.allowedObjectTypeProperties)
+                  .filter(([, properties]) => properties.length > 0)
+                  .map(([objectType]) => objectType)
+            : opts.ir.objectTypes.map((objectType) => objectType.name)
+    );
+
+    const objectTypes =
+        projectionMode === "legacy"
+            ? opts.ir.objectTypes
+            : opts.ir.objectTypes
+                  .filter((objectType) => visibleObjectTypes.has(objectType.name))
+                  .map((objectType) => {
+                      const allowed = new Set(opts.allowedObjectTypeProperties[objectType.name] ?? []);
+                      return {
+                          ...objectType,
+                          title:
+                              objectType.title && allowed.has(objectType.title) ? objectType.title : undefined,
+                          properties: objectType.properties.filter((property) => allowed.has(property.name)),
+                      };
+                  });
+
+    const linkTypes =
+        projectionMode === "legacy"
+            ? opts.ir.linkTypes
+            : opts.ir.linkTypes.filter((link) => {
+                  if (
+                      !visibleObjectTypes.has(link.source.objectType) ||
+                      !visibleObjectTypes.has(link.target.objectType)
+                  ) {
+                      return false;
+                  }
+                  if (!link.foreignKey) return true;
+                  const sourceAllowed = new Set(
+                      opts.allowedObjectTypeProperties[link.source.objectType] ?? []
+                  );
+                  const targetAllowed = new Set(
+                      opts.allowedObjectTypeProperties[link.target.objectType] ?? []
+                  );
+                  return sourceAllowed.has(link.foreignKey) || targetAllowed.has(link.foreignKey);
+              });
+
+    const visibleActions =
+        opts.visibleActionTypes === undefined || opts.visibleActionTypes === "all"
+            ? opts.ir.actionTypes
+            : opts.ir.actionTypes.filter((actionType) =>
+                  (opts.visibleActionTypes as readonly string[]).includes(actionType.name)
+              );
+
+    const actionTypes = visibleActions
+        .filter(
+            (actionType) =>
+                projectionMode === "legacy" ||
+                !actionParametersReferenceHiddenObjectType(actionType, opts.ir, visibleObjectTypes)
+        )
+        .map((actionType) => {
             const visibleParameters = new Set(
                 actionType.parameters
                     .filter(
@@ -315,6 +474,13 @@ export function projectRemoteOntologyIR<
                 ...actionType,
                 parameters: actionType.parameters.filter((parameter) => visibleParameters.has(parameter.name)),
                 logic: actionType.logic.flatMap((step) => {
+                    if (
+                        projectionMode === "authorized" &&
+                        step.kind === "createObject" &&
+                        !visibleObjectTypes.has(step.value.objectType)
+                    ) {
+                        return [];
+                    }
                     const projectedStep = projectLogicStep({
                         step,
                         serverContext: opts.serverContext,
@@ -329,7 +495,54 @@ export function projectRemoteOntologyIR<
                     return projectedStep ? [projectedStep] : [];
                 }),
             };
-        }),
+        });
+
+    const queryFunctionTypes =
+        opts.visibleQueryFunctionTypes === undefined || opts.visibleQueryFunctionTypes === "all"
+            ? opts.ir.queryFunctionTypes.filter((queryFunction) => {
+                  if (projectionMode === "legacy") return true;
+                  for (const parameter of queryFunction.parameters) {
+                      for (const objectType of typeReferencesObjectTypes(parameter.type, opts.ir)) {
+                          if (!visibleObjectTypes.has(objectType)) return false;
+                      }
+                  }
+                  for (const objectType of typeReferencesObjectTypes(queryFunction.returnType, opts.ir)) {
+                      if (!visibleObjectTypes.has(objectType)) return false;
+                  }
+                  return true;
+              })
+            : opts.ir.queryFunctionTypes.filter((queryFunction) =>
+                  (opts.visibleQueryFunctionTypes as readonly string[]).includes(queryFunction.name)
+              );
+
+    const referencedNamedTypes = new Set<string>();
+    for (const objectType of objectTypes) {
+        for (const property of objectType.properties) {
+            collectReferencedNamedTypes(property.type, opts.ir, referencedNamedTypes);
+        }
+    }
+    for (const actionType of actionTypes) {
+        for (const parameter of actionType.parameters) {
+            collectReferencedNamedTypes(parameter.type, opts.ir, referencedNamedTypes);
+        }
+    }
+    for (const queryFunction of queryFunctionTypes) {
+        for (const parameter of queryFunction.parameters) {
+            collectReferencedNamedTypes(parameter.type, opts.ir, referencedNamedTypes);
+        }
+        collectReferencedNamedTypes(queryFunction.returnType, opts.ir, referencedNamedTypes);
+    }
+
+    return {
+        ...opts.ir,
+        types:
+            projectionMode === "legacy"
+                ? opts.ir.types
+                : opts.ir.types.filter((type) => referencedNamedTypes.has(type.name)),
+        objectTypes,
+        linkTypes,
+        actionTypes,
+        queryFunctionTypes,
     };
 }
 

--- a/packages/remote-ontology/src/server.test.ts
+++ b/packages/remote-ontology/src/server.test.ts
@@ -5,7 +5,7 @@ import {
     type OntologyBackendAdapter,
     type OntologyIR,
 } from "@party-stack/ontology";
-import { eq, gt, IR } from "@tanstack/db";
+import { eq, gt, IR, queryOnce } from "@tanstack/db";
 import { createRemoteOntologyServer } from "./server.js";
 import { parseRemoteOntologyJson, serializeRemoteOntologyJson } from "./protocol.js";
 import type { RemoteOntologyDescription } from "./protocol.js";
@@ -334,5 +334,164 @@ describe("remote ontology server policy projection", () => {
                 },
             ],
         });
+    });
+
+    it("starts on-demand collections for apply-action without hanging", async () => {
+        let syncStarted = false;
+        let cleanedUp = false;
+        const onDemandIr: OntologyIR = {
+            ...ir,
+            objectTypes: [noteObjectType],
+            actionTypes: [
+                {
+                    name: "createNote",
+                    displayName: "Create note",
+                    parameters: [
+                        { name: "title", displayName: "Title", type: o.string({}) },
+                        {
+                            name: "note",
+                            displayName: "Note",
+                            type: o.objectReference({ objectType: "Note" }),
+                        },
+                    ],
+                    logic: [
+                        o.ActionLogicStep.createObject({
+                            objectType: "Note",
+                            values: [
+                                {
+                                    property: ["id"],
+                                    value: o.Expression.literal({ value: "created" }),
+                                },
+                            ],
+                        }),
+                    ],
+                },
+            ],
+        };
+        const backendAdapter: OntologyBackendAdapter = {
+            name: "test",
+            getCollectionOptions: () => ({
+                syncMode: "on-demand",
+                sync: {
+                    sync: ({ begin, write, commit, markReady }) => {
+                        syncStarted = true;
+                        begin({ immediate: true });
+                        write({
+                            type: "insert",
+                            value: {
+                                id: "note-1",
+                                ownerEmail: "alice@example.com",
+                                status: "open",
+                                priority: 1,
+                            },
+                        });
+                        commit();
+                        queueMicrotask(() => markReady());
+                        return {
+                            loadSubset: () => true as const,
+                            cleanup: () => {
+                                cleanedUp = true;
+                            },
+                        };
+                    },
+                },
+            }),
+            applyAction: async () => {},
+            runQueryFunction: async () => undefined,
+        };
+        const server = createRemoteOntologyServer<any, any>({
+            ir: onDemandIr,
+            backendAdapter,
+            getContext: () => ({ user: { email: "alice@example.com" } }),
+            policy: {
+                canApplyAction: async (_ctx, request, { objects }) => {
+                    const note = await queryOnce((q) =>
+                        q
+                            .from({ object: objects.Note! })
+                            .where(({ object }) => eq((object as any).id, request.parameters.note))
+                            .findOne()
+                    );
+                    return note != null;
+                },
+                baseObjectTypeQueries: {
+                    Note: ({ q, collection }: { q: any; collection: any }) =>
+                        q.from({ object: collection }),
+                } as any,
+            },
+        });
+
+        const response = await server.handleRequest(
+            new Request("http://example.test/apply-action", {
+                method: "POST",
+                body: serializeRemoteOntologyJson({
+                    actionType: "createNote",
+                    parameters: {
+                        title: "Hello",
+                        note: "note-1",
+                    },
+                }),
+            })
+        );
+
+        expect(response.status).toBe(200);
+        expect(syncStarted).toBe(true);
+        expect(cleanedUp).toBe(true);
+        expect(parseRemoteOntologyJson(await response.text())).toMatchObject({
+            invalidatedObjectTypes: ["Note"],
+        });
+    });
+
+    it("cleans up on-demand collections after apply-action failure", async () => {
+        let cleanedUp = false;
+        const onDemandIr: OntologyIR = {
+            ...ir,
+            objectTypes: [noteObjectType],
+        };
+        const backendAdapter: OntologyBackendAdapter = {
+            name: "test",
+            getCollectionOptions: () => ({
+                syncMode: "on-demand",
+                sync: {
+                    sync: ({ markReady }) => {
+                        queueMicrotask(() => markReady());
+                        return {
+                            loadSubset: () => true as const,
+                            cleanup: () => {
+                                cleanedUp = true;
+                            },
+                        };
+                    },
+                },
+            }),
+            applyAction: async () => {
+                throw new Error("backend failed");
+            },
+            runQueryFunction: async () => undefined,
+        };
+        const server = createRemoteOntologyServer<any, any>({
+            ir: onDemandIr,
+            backendAdapter,
+            getContext: () => ({}),
+            policy: {
+                canApplyAction: () => true,
+            },
+        });
+
+        const response = await server.handleRequest(
+            new Request("http://example.test/apply-action", {
+                method: "POST",
+                body: serializeRemoteOntologyJson({
+                    actionType: "createNote",
+                    parameters: {
+                        title: "Hello",
+                        ownerEmail: "alice@example.com",
+                        dueDate: "2026-06-15",
+                    },
+                }),
+            })
+        );
+
+        expect(response.status).toBe(500);
+        expect(cleanedUp).toBe(true);
     });
 });

--- a/packages/remote-ontology/src/server.ts
+++ b/packages/remote-ontology/src/server.ts
@@ -6,7 +6,10 @@ import {
     type QueryBuilder,
     type Context as QueryBuilderContext,
 } from "@tanstack/db";
-import { createLiveOntology } from "@party-stack/ontology";
+import {
+    createLiveOntology,
+    waitForLiveOntologyReady,
+} from "@party-stack/ontology";
 import { decode, encode } from "@party-stack/ontology/json";
 import { MemoryBlobBytesStore, SingleProcessCoordination } from "@party-stack/runtime";
 import type {
@@ -19,6 +22,12 @@ import type {
     PartialAttachmentMetadata,
 } from "@party-stack/ontology";
 import {
+    parseRemoteOntologyErrorBody,
+    remoteOntologyErrorFromUnknown,
+    RemoteOntologyError,
+    statusToCode,
+} from "./errors.js";
+import {
     parseRemoteOntologyJson,
     parseRemoteOntologyRequest,
     remoteOntologyEndpointSchema,
@@ -29,6 +38,7 @@ import {
     projectRemoteOntologyIR,
     type ClientContextProjectionMode,
     type FixedActionParameterValues,
+    type RemoteOntologySchemaProjectionMode,
 } from "./securedOntology.js";
 import type {
     RemoteApplyActionRequest,
@@ -133,6 +143,25 @@ export interface RemoteOntologyPolicy<Context, Ontology extends OntologyDefiniti
     allowedObjectTypeProperties?: RemoteOntologyAllowedObjectTypeProperties<Context, Ontology>;
     fixedActionParameterValues?: FixedActionParameterValues<Ontology>;
     clientContext?: RemoteOntologyClientContextPolicy<Context>;
+    /**
+     * Schema describe projection mode.
+     * Defaults to `authorized` when object visibility policy is configured, otherwise `legacy`.
+     */
+    schemaProjectionMode?: RemoteOntologySchemaProjectionMode;
+    /**
+     * Optional action-type visibility for describe. Defaults to all action types.
+     */
+    visibleActionTypes?:
+        | readonly string[]
+        | "all"
+        | ((ctx: Context) => readonly string[] | "all" | Promise<readonly string[] | "all">);
+    /**
+     * Optional query-function visibility for describe. Defaults to all query functions.
+     */
+    visibleQueryFunctionTypes?:
+        | readonly string[]
+        | "all"
+        | ((ctx: Context) => readonly string[] | "all" | Promise<readonly string[] | "all">);
     canApplyAction?: (
         ctx: Context,
         request: RemoteOntologyApplyActionRequest<Ontology>,
@@ -180,17 +209,31 @@ function jsonResponse(body: unknown, init?: ResponseInit): Response {
     });
 }
 
-function errorResponse(error: unknown, status: number = 500): Response {
-    if (status >= 500) {
+function errorResponse(error: unknown, status?: number): Response {
+    const remoteError = remoteOntologyErrorFromUnknown(error);
+    if (status !== undefined && status !== remoteError.status) {
+        // Preserve explicit status overrides while keeping structured fields.
+        const overridden = new RemoteOntologyError({
+            name: remoteError.name,
+            code: statusToCode(status),
+            status,
+            message: remoteError.message,
+            details: remoteError.details,
+            cause: error,
+        });
+        if (overridden.status >= 500) {
+            console.error("Remote ontology request failed.", error);
+        }
+        return jsonResponse(overridden.toJSON(), { status: overridden.status });
+    }
+    if (remoteError.status >= 500) {
         console.error("Remote ontology request failed.", error);
     }
-    const message = error instanceof Error ? error.message : String(error);
-    return jsonResponse({ error: message }, { status });
+    return jsonResponse(remoteError.toJSON(), { status: remoteError.status });
 }
 
 function getErrorStatus(error: unknown): number {
-    if (error instanceof Error && error.name === "RemoteOntologyForbiddenError") return 403;
-    return error instanceof Error && error.name === "ZodError" ? 400 : 500;
+    return remoteOntologyErrorFromUnknown(error).status;
 }
 
 class RemoteOntologyForbiddenError extends Error {
@@ -218,20 +261,27 @@ async function resolveValue<Context, TValue>(
     return valueOrFactory;
 }
 
-async function waitForLiveOntologyReady(ontology: LiveOntology): Promise<void> {
-    await Promise.all(
-        Object.values(ontology.objects).map(async (collection) => {
-            if (collection.status === "ready") return;
-            if (collection.status === "error" || collection.status === "cleaned-up") {
-                throw new Error(`Collection "${collection.id}" is ${collection.status}.`);
-            }
-            await (
-                collection as typeof collection & {
-                    waitFor: (event: "status:ready") => Promise<unknown>;
-                }
-            ).waitFor("status:ready");
-        })
-    );
+function getInvalidatedObjectTypesFromActionLogic(
+    ir: OntologyIR,
+    actionType: string
+): string[] | undefined {
+    const action = ir.actionTypes.find((candidate) => candidate.name === actionType);
+    if (!action) return undefined;
+    const objectTypes = new Set<string>();
+    for (const step of action.logic) {
+        if (step.kind === "createObject") {
+            objectTypes.add(step.value.objectType);
+            continue;
+        }
+        if (step.kind === "updateObject" || step.kind === "deleteObject") {
+            const parameterName = step.value.object.path[0];
+            if (!parameterName) continue;
+            const parameter = action.parameters.find((candidate) => candidate.name === parameterName);
+            if (!parameter || parameter.type.kind !== "objectReference") continue;
+            objectTypes.add(parameter.type.value.objectType);
+        }
+    }
+    return objectTypes.size > 0 ? [...objectTypes] : undefined;
 }
 
 function normalizePath(pathname: string): string {
@@ -500,6 +550,19 @@ async function handleDescribe<Context, Ontology extends OntologyDefinition = Ont
 ): Promise<RemoteOntologyDescription> {
     const ir = await resolveValue(opts.ir, ctx);
     const clientContext = await resolveClientContext(ctx, opts.policy);
+    const hasObjectVisibilityPolicy =
+        opts.policy?.allowedObjectTypeProperties !== undefined ||
+        opts.policy?.baseObjectTypeQueries !== undefined;
+    const projectionMode =
+        opts.policy?.schemaProjectionMode ?? (hasObjectVisibilityPolicy ? "authorized" : "legacy");
+    const visibleActionTypes =
+        typeof opts.policy?.visibleActionTypes === "function"
+            ? await opts.policy.visibleActionTypes(ctx)
+            : opts.policy?.visibleActionTypes;
+    const visibleQueryFunctionTypes =
+        typeof opts.policy?.visibleQueryFunctionTypes === "function"
+            ? await opts.policy.visibleQueryFunctionTypes(ctx)
+            : opts.policy?.visibleQueryFunctionTypes;
     return {
         ir: projectRemoteOntologyIR({
             ir,
@@ -508,6 +571,9 @@ async function handleDescribe<Context, Ontology extends OntologyDefinition = Ont
             clientContextMode: clientContext.mode,
             fixedActionParameterValues: opts.policy?.fixedActionParameterValues,
             allowedObjectTypeProperties: resolveProjectedAllowedObjectTypeProperties(ctx, ir, opts.policy),
+            projectionMode,
+            visibleActionTypes,
+            visibleQueryFunctionTypes,
         }),
         ...(clientContext.context ? { context: clientContext.context } : {}),
     };
@@ -556,7 +622,11 @@ async function handleApplyAction<Context, Ontology extends OntologyDefinition = 
         await waitForLiveOntologyReady(ontology);
         const canApply = await opts.policy?.canApplyAction?.(
             ctx,
-            request as RemoteOntologyApplyActionRequest<Ontology>,
+            {
+                actionType: request.actionType,
+                parameters,
+                idempotencyKey: executionId,
+            } as unknown as RemoteOntologyApplyActionRequest<Ontology>,
             {
                 objects: ontology.objects,
             }
@@ -570,15 +640,20 @@ async function handleApplyAction<Context, Ontology extends OntologyDefinition = 
             throw new Error(`Unknown action "${request.actionType}".`);
         }
         actionResult = await action(parameters, {
-            idempotencyKey: request.idempotencyKey,
+            idempotencyKey: executionId,
         });
     } finally {
         coordination.close();
         await ontology.cleanup();
     }
 
+    const invalidatedObjectTypes =
+        actionResult?.invalidatedObjectTypes ??
+        getInvalidatedObjectTypesFromActionLogic(ir, request.actionType) ??
+        ir.objectTypes.map((objectType) => objectType.name);
+
     return {
-        invalidatedObjectTypes: ir.objectTypes.map((objectType) => objectType.name),
+        invalidatedObjectTypes,
         attachmentIdMappings: actionResult?.attachmentIdMappings,
     };
 }

--- a/packages/sqlite-ontology/src/index.test.ts
+++ b/packages/sqlite-ontology/src/index.test.ts
@@ -1,5 +1,6 @@
 import { createRequire } from "node:module";
 import { createLiveOntology, o, type OntologyIR } from "@party-stack/ontology";
+import { eq, queryOnce } from "@tanstack/db";
 import { afterEach, describe, expect, it } from "vitest";
 import type { attachment as OntologyAttachment } from "@party-stack/ontology/values";
 import { createSQLiteOntologyBackendAdapter } from "./index.js";
@@ -20,8 +21,29 @@ const BetterSqlite3 = require("better-sqlite3") as unknown;
 const Database = BetterSqlite3 as new (path: string) => TestDatabase;
 
 const ir: OntologyIR = {
-    types: [],
+    types: [
+        {
+            name: "NoteMeta",
+            description: "Note metadata",
+            type: o.struct({
+                fields: [
+                    { name: "priority", displayName: "Priority", type: o.integer({}) },
+                    { name: "source", displayName: "Source", type: o.string({}) },
+                ],
+            }),
+        },
+    ],
     objectTypes: [
+        {
+            name: "Author",
+            displayName: "Author",
+            pluralDisplayName: "Authors",
+            primaryKey: "id",
+            properties: [
+                { name: "id", displayName: "ID", type: o.string({}) },
+                { name: "email", displayName: "Email", type: o.string({}) },
+            ],
+        },
         {
             name: "Note",
             displayName: "Note",
@@ -30,6 +52,18 @@ const ir: OntologyIR = {
             properties: [
                 { name: "id", displayName: "ID", type: o.string({}) },
                 { name: "title", displayName: "Title", type: o.string({}) },
+                { name: "ownerEmail", displayName: "Owner email", type: o.string({}) },
+                { name: "authorId", displayName: "Author ID", type: o.string({}) },
+                {
+                    name: "tags",
+                    displayName: "Tags",
+                    type: o.list({ elementType: o.string({}) }),
+                },
+                {
+                    name: "meta",
+                    displayName: "Meta",
+                    type: o.ref({ name: "NoteMeta" }),
+                },
                 { name: "updatedAt", displayName: "Updated at", type: o.timestamp({}) },
             ],
         },
@@ -45,14 +79,66 @@ const ir: OntologyIR = {
             ],
         },
     ],
-    linkTypes: [],
+    linkTypes: [
+        {
+            id: "note-author",
+            source: { objectType: "Note", name: "notes", displayName: "Notes" },
+            target: { objectType: "Author", name: "author", displayName: "Author" },
+            foreignKey: "authorId",
+            cardinality: "many",
+        },
+    ],
     actionTypes: [
+        {
+            name: "createAuthor",
+            displayName: "Create author",
+            parameters: [
+                { name: "id", displayName: "ID", type: o.string({}) },
+                { name: "email", displayName: "Email", type: o.string({}) },
+            ],
+            logic: [
+                o.ActionLogicStep.createObject({
+                    objectType: "Author",
+                    values: [
+                        {
+                            property: ["id"],
+                            value: o.Expression.valueReference({ path: ["id"] }),
+                        },
+                        {
+                            property: ["email"],
+                            value: o.Expression.valueReference({ path: ["email"] }),
+                        },
+                    ],
+                }),
+            ],
+        },
         {
             name: "createNote",
             displayName: "Create note",
             parameters: [
                 { name: "id", displayName: "ID", type: o.string({}) },
                 { name: "title", displayName: "Title", type: o.string({}) },
+                {
+                    name: "ownerEmail",
+                    displayName: "Owner email",
+                    type: o.string({}),
+                    defaultValue: o.Expression.contextReference({ path: ["user", "email"] }),
+                },
+                {
+                    name: "author",
+                    displayName: "Author",
+                    type: o.objectReference({ objectType: "Author" }),
+                },
+                {
+                    name: "tags",
+                    displayName: "Tags",
+                    type: o.list({ elementType: o.string({}) }),
+                },
+                {
+                    name: "meta",
+                    displayName: "Meta",
+                    type: o.ref({ name: "NoteMeta" }),
+                },
             ],
             logic: [
                 o.ActionLogicStep.createObject({
@@ -65,6 +151,22 @@ const ir: OntologyIR = {
                         {
                             property: ["title"],
                             value: o.Expression.valueReference({ path: ["title"] }),
+                        },
+                        {
+                            property: ["ownerEmail"],
+                            value: o.Expression.valueReference({ path: ["ownerEmail"] }),
+                        },
+                        {
+                            property: ["authorId"],
+                            value: o.Expression.valueReference({ path: ["author"] }),
+                        },
+                        {
+                            property: ["tags"],
+                            value: o.Expression.valueReference({ path: ["tags"] }),
+                        },
+                        {
+                            property: ["meta"],
+                            value: o.Expression.valueReference({ path: ["meta"] }),
                         },
                         {
                             property: ["updatedAt"],
@@ -123,10 +225,14 @@ const ir: OntologyIR = {
     queryFunctionTypes: [],
 };
 
-describe("createSQLiteOntologyBackendAdapter", () => {
+describe("SQLite LiveOntology MVP acceptance", () => {
     const databases: TestDatabase[] = [];
+    const ontologies: Array<{ cleanup: () => Promise<void> }> = [];
 
-    afterEach(() => {
+    afterEach(async () => {
+        for (const ontology of ontologies.splice(0)) {
+            await ontology.cleanup();
+        }
         for (const database of databases.splice(0)) {
             database.close();
         }
@@ -138,22 +244,96 @@ describe("createSQLiteOntologyBackendAdapter", () => {
         return database;
     }
 
-    it("persists action mutations and hydrates Temporal values on reload", async () => {
+    async function createOntology(opts?: { context?: Record<string, unknown>; name?: string }) {
         const database = createDatabase();
         const backendAdapter = createSQLiteOntologyBackendAdapter({
             ir,
             database,
-            name: "test",
+            name: opts?.name ?? "test",
         });
         const ontology = await createLiveOntology({
             ir,
             backend: () => backendAdapter,
+            context: opts?.context,
         });
+        ontologies.push(ontology);
+        return { database, ontology };
+    }
 
+    async function readObjectById(
+        collection: { get: (id: string) => unknown },
+        primaryKey: string,
+        id: string
+    ) {
+        await queryOnce((q) =>
+            q
+                .from({ object: collection as never })
+                .where(({ object }) => eq((object as Record<string, unknown>)[primaryKey], id))
+                .select(({ object }) => object)
+        );
+        return collection.get(id);
+    }
+
+    it("supports primitive, struct, list, object-reference, and defaultValue parameters", async () => {
+        const { ontology } = await createOntology({
+            context: { user: { email: "alice@example.com" } },
+        });
+        await ontology.ready;
+
+        await ontology.actions.createAuthor!({
+            id: "author-1",
+            email: "author@example.com",
+        });
         await ontology.actions.createNote!({
             id: "note-1",
             title: "Hello",
+            author: "author-1",
+            tags: ["mvp", "sqlite"],
+            meta: { priority: 2, source: "demo" },
         });
+
+        const note = (await readObjectById(ontology.objects.Note!, "id", "note-1")) as Record<
+            string,
+            unknown
+        >;
+        expect(note).toMatchObject({
+            id: "note-1",
+            title: "Hello",
+            ownerEmail: "alice@example.com",
+            authorId: "author-1",
+            tags: ["mvp", "sqlite"],
+            meta: { priority: 2, source: "demo" },
+        });
+        expect(note.updatedAt).toHaveProperty("epochMilliseconds");
+        expect(
+            ((await readObjectById(ontology.objects.Author!, "id", "author-1")) as { email: string })
+                .email
+        ).toBe("author@example.com");
+        expect(ir.linkTypes[0]).toMatchObject({
+            foreignKey: "authorId",
+            cardinality: "many",
+        });
+    });
+
+    it("persists action mutations and hydrates Temporal values on reload", async () => {
+        const { database, ontology } = await createOntology({
+            context: { user: { email: "alice@example.com" } },
+        });
+        await ontology.ready;
+
+        await ontology.actions.createAuthor!({
+            id: "author-1",
+            email: "author@example.com",
+        });
+        await ontology.actions.createNote!({
+            id: "note-1",
+            title: "Hello",
+            author: "author-1",
+            tags: ["reload"],
+            meta: { priority: 1, source: "persist" },
+        });
+        await ontology.cleanup();
+        ontologies.splice(ontologies.indexOf(ontology), 1);
 
         const reloadedOntology = await createLiveOntology({
             ir,
@@ -163,28 +343,34 @@ describe("createSQLiteOntologyBackendAdapter", () => {
                     database,
                     name: "test",
                 }),
+            context: { user: { email: "alice@example.com" } },
         });
+        ontologies.push(reloadedOntology);
+        await reloadedOntology.ready;
 
         const note = reloadedOntology.objects.Note!.get("note-1");
         expect(note?.title).toBe("Hello");
+        expect(note?.tags).toEqual(["reload"]);
+        expect(note?.meta).toEqual({ priority: 1, source: "persist" });
         expect(note?.updatedAt).toHaveProperty("epochMilliseconds");
     });
 
     it("stores action attachment uploads in SQLite", async () => {
-        const database = createDatabase();
-        const backendAdapter = createSQLiteOntologyBackendAdapter({
-            ir,
-            database,
-            name: "test",
+        const { ontology } = await createOntology({
+            context: { user: { email: "alice@example.com" } },
         });
-        const ontology = await createLiveOntology({
-            ir,
-            backend: () => backendAdapter,
-        });
+        await ontology.ready;
 
+        await ontology.actions.createAuthor!({
+            id: "author-1",
+            email: "author@example.com",
+        });
         await ontology.actions.createNote!({
             id: "note-1",
             title: "Hello",
+            author: "author-1",
+            tags: [],
+            meta: { priority: 0, source: "attachment" },
         });
         const creation = await ontology.attachments.create(
             new File(["hello attachment"], "hello.txt", { type: "text/plain" }),
@@ -213,5 +399,23 @@ describe("createSQLiteOntologyBackendAdapter", () => {
             type: "text/plain",
         });
         expect(await blob.text()).toBe("hello attachment");
+        expect(
+            (
+                (await readObjectById(
+                    ontology.objects.NoteAttachment!,
+                    "id",
+                    "attachment-object-1"
+                )) as { noteId: string }
+            ).noteId
+        ).toBe("note-1");
+    });
+
+    it("supports safe initialization and idempotent cleanup", async () => {
+        const { ontology } = await createOntology({
+            context: { user: { email: "alice@example.com" } },
+        });
+        await ontology.ready;
+        await ontology.cleanup();
+        await expect(ontology.cleanup()).resolves.toBeUndefined();
     });
 });


### PR DESCRIPTION
## Summary

Upstream Party Stack bits Streamline Gateway needs to run LiveOntology without OSDK.

Fixes the stuff Gateway was working around: on-demand collection readiness (so apply-action doesn’t hang), safer cleanup/`ready`, non-blocking action refresh, structured remote errors, and policy-aware describe. Keeps public Foundry action metadata; stays backend-neutral (SQLite demos still work).

Not in this MVP: generic/non-FK link traversal, object-query helpers, or OMS prefills. Gateway keeps FK joins + OMS/prefill on its side and fails closed for the rest.

Pairs with Streamline’s `migrate-streamline-gateway` work (live form submit over remote LiveOntology, policy server, live vs legacy split).

Tested by running gateway locally with local party-stack changes